### PR TITLE
Typo in first example made the code invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ class Carousel extends React.Component {
     return (
       <div
         role="tablist"
-        className={classes({
+        className={classes(
           classNames.carousel,
           animating && classNames.carousel__animating,
-        })}
+        )}
       >
         <ul className={classNames.list}>
           {children}


### PR DESCRIPTION
```js
 <div
        role="tablist"
        className={classes(
          classNames.carousel,
          animating && classNames.carousel__animating,
        )}
      >
``` 
was invalid due to extraneous `{}`, I removed them

@milesj 