### PR TITLE
Pass down a new `cx` prop

### DIFF
--- a/docs/integrations/react.md
+++ b/docs/integrations/react.md
@@ -44,11 +44,11 @@ supports all of the [options](#options) mentioned previously as props, except fo
 
 ```ts
 // withStyles.ts
-import { withStylesFactory, WithStylesProps as BaseWithStylesProps } from 'aesthetic-react';
-import { ParsedBlock } from 'aesthetic-adapter-aphrodite'; // Or your adapter
+import { withStylesFactory, WithStylesWrappedProps } from 'aesthetic-react';
+import { NativeBlock, ParsedBlock } from 'aesthetic-adapter-aphrodite'; // Or your adapter
 import aesthetic, { Theme } from './aesthetic';
 
-export type WithStylesProps = BaseWithStylesProps<Theme, ParsedBlock>;
+export type WithStylesProps = WithStylesWrappedProps<Theme, NativeBlock, ParsedBlock>;
 
 export default withStylesFactory(aesthetic);
 ```
@@ -61,10 +61,10 @@ mentioned previously as props.
 
 ```ts
 // withTheme.ts
-import { withThemeFactory, WithThemeProps as BaseWithThemeProps } from 'aesthetic-react';
+import { withThemeFactory, WithThemeWrappedProps } from 'aesthetic-react';
 import aesthetic, { Theme } from './aesthetic';
 
-export type WithThemeProps = BaseWithThemeProps<Theme>;
+export type WithThemeProps = WithThemeWrappedProps<Theme>;
 
 export default withThemeFactory(aesthetic);
 ```

--- a/docs/migrate/4.0.md
+++ b/docs/migrate/4.0.md
@@ -7,10 +7,30 @@ been made.
 > [official changelog](https://github.com/milesj/aesthetic/blob/master/packages/core/CHANGELOG.md)
 > for other changes.
 
-## React utilites have moved to their own package
+## Core
 
-All React functionality and utilities have moved to the new `aesthetic-react` package. This
-primarily includes the hook and HOC helpers.
+### Styles can no longer be spread
+
+The `Aesthetic#transformStyles` method that generates CSS class names from parsed styles, has been
+updated to requires all styles to be passed as an array to the 1st argument, instead of being spread
+through many arguments. This change was made to support future options objects.
+
+```ts
+// Old
+const className = aesthetic.transformStyles(styles.foo, var && styles.bar);
+
+// New
+const className = aesthetic.transformStyles([styles.foo, var && styles.bar]);
+```
+
+> This does not change the `cx` function, which still accepts spreading.
+
+## React
+
+### Moved to a new package
+
+All React functionality and utilities have moved to the new `aesthetic-react` package, and off of
+the `Aesthetic` instance. This primarily includes the hook and HOC helpers.
 
 ```tsx
 // Old
@@ -50,7 +70,48 @@ export default withStyles(theme => ({
 This new factory pattern has been applied to all hooks and HOCs, so be sure to read the new
 [React integration docs](../integrations/react.md).
 
-## Renamed React types
+### Class name transformer is now passed as a prop
+
+The function to transform parsed styles into CSS class names, commonly referred as `cx` or `css`, is
+now passed as prop named `cx` when using `withStyles`. Previously this function was factoried and
+imported separately.
+
+```tsx
+// Old
+import React from 'react';
+import withStyles from './withStyles';
+import cx from './cx';
+
+function Button({ props, styles }) {
+  return <button className={cx(styles.button)} />;
+}
+
+export default withStyles(theme => ({
+  button: {
+    padding: theme.unit,
+  },
+}))(Button);
+```
+
+```tsx
+// New
+import React from 'react';
+import withStyles from './withStyles';
+
+function Button({ props, cx, styles }) {
+  return <button className={cx(styles.button)} />;
+}
+
+export default withStyles(theme => ({
+  button: {
+    padding: theme.unit,
+  },
+}))(Button);
+```
+
+> The name of this prop can be customized with the `cxPropName` option.
+
+### Renamed interface types
 
 The `WithStylesProps` and `WithThemeProps` interfaces were renamed to `WithStylesWrappedProps` and
 `WithThemeWrappedProps` respectively. `WithStylesWrappedProps` also requires the native block type

--- a/docs/migrate/4.0.md
+++ b/docs/migrate/4.0.md
@@ -49,3 +49,32 @@ export default withStyles(theme => ({
 
 This new factory pattern has been applied to all hooks and HOCs, so be sure to read the new
 [React integration docs](../integrations/react.md).
+
+## Renamed React types
+
+The `WithStylesProps` and `WithThemeProps` interfaces were renamed to `WithStylesWrappedProps` and
+`WithThemeWrappedProps` respectively. `WithStylesWrappedProps` also requires the native block type
+to be passed from the adapter.
+
+```ts
+// Old
+import {
+  WithStylesProps as BaseWithStylesProps,
+  WithThemeProps as BaseWithThemeProps,
+} from 'aesthetic';
+import { ParsedBlock } from 'aesthetic-adapter-aphrodite';
+import { Theme } from './aesthetic';
+
+export type WithStylesProps = BaseWithStylesProps<Theme, ParsedBlock>;
+export type WithThemeProps = BaseWithThemeProps<Theme>;
+```
+
+```ts
+// New
+import { WithStylesWrappedProps, WithThemeWrappedProps } from 'aesthetic-react';
+import { NativeBlock, ParsedBlock } from 'aesthetic-adapter-aphrodite';
+import { Theme } from './aesthetic';
+
+export type WithStylesProps = WithStylesWrappedProps<Theme, NativeBlock, ParsedBlock>;
+export type WithThemeProps = WithThemeWrappedProps<Theme>;
+```

--- a/docs/migrate/4.0.md
+++ b/docs/migrate/4.0.md
@@ -72,9 +72,12 @@ This new factory pattern has been applied to all hooks and HOCs, so be sure to r
 
 ### Class name transformer is now passed as a prop
 
-The function to transform parsed styles into CSS class names, commonly referred as `cx` or `css`, is
-now passed as prop named `cx` when using `withStyles`. Previously this function was factoried and
+The function to transform parsed styles into CSS class names, commonly referred to as `cx` or `css`,
+is now passed as prop named `cx` when using `withStyles`. Previously this function was factoried and
 imported separately.
+
+No changes are required for `useStyles`, since the `cx` function was already returned as the 2nd
+tuple value.
 
 ```tsx
 // Old

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,6 +17,8 @@ export default new AphroditeAesthetic(extensions, {
 
 The following options are available, most of which can be overridden per component.
 
+- `cxPropName` (string) - Name of the prop in which to pass the styles to CSS class name transformer
+  function. Defaults to `cx`.
 - `extendable` (boolean) - Can component styles be extended by other components? Otherwise, the
   styles are locked and isolated. Defaults to `false`.
 - `passThemeProp` (boolean) - Should the theme prop be passed to all wrapped components? Defaults to

--- a/docs/style.md
+++ b/docs/style.md
@@ -25,7 +25,7 @@ aesthetic.setStyleSheet('button-component', theme => ({
 Once the style sheet is defined, the second phase will parse and process it using the underlying
 adapter (like Aphrodite). This is triggered by the `Aesthetic#createStyleSheet` method, which
 requires the unique style name from the previous example, and returns a cached and parsed style
-sheet. This parsed style sheet is then using to generate [CSS class names](#generating-class-names).
+sheet. This parsed style sheet is then used to generate [CSS class names](#generating-class-names).
 
 ```ts
 const styles = aesthetic.createStyleSheet('button-component');

--- a/packages/adapter-aphrodite/tests/AphroditeAesthetic.test.ts
+++ b/packages/adapter-aphrodite/tests/AphroditeAesthetic.test.ts
@@ -44,7 +44,7 @@ describe('AphroditeAesthetic', () => {
 
     expect(nativeSheet).toEqual(expStyles);
 
-    expect(instance.transformStyles(...Object.values(styleSheet))).toBe(expClassName);
+    expect(instance.transformStyles(Object.values(styleSheet))).toBe(expClassName);
 
     if (raw) {
       // @ts-ignore

--- a/packages/adapter-css-modules/tests/CSSModulesAesthetic.test.ts
+++ b/packages/adapter-css-modules/tests/CSSModulesAesthetic.test.ts
@@ -7,7 +7,7 @@ describe('CSSModulesAesthetic', () => {
     // eslint-disable-next-line global-require
     const classes = require('./styles.css');
 
-    expect(instance.transformStyles(classes.header, classes.footer)).toBe(
+    expect(instance.transformStyles([classes.header, classes.footer])).toBe(
       'styles__header___3JVTA styles__footer___1Vp0S',
     );
   });

--- a/packages/adapter-fela/tests/FelaAesthetic.test.ts
+++ b/packages/adapter-fela/tests/FelaAesthetic.test.ts
@@ -49,7 +49,7 @@ describe('FelaAesthetic', () => {
 
     expect(nativeSheet).toEqual(expStyles);
 
-    expect(instance.transformStyles(...Object.values(styleSheet))).toBe(expClassName);
+    expect(instance.transformStyles(Object.values(styleSheet))).toBe(expClassName);
 
     expect(cleanStyles(renderToString(instance.fela))).toMatchSnapshot();
   }

--- a/packages/adapter-jss/tests/JSSAesthetic.test.ts
+++ b/packages/adapter-jss/tests/JSSAesthetic.test.ts
@@ -70,7 +70,7 @@ describe('JSSAesthetic', () => {
 
     expect(nativeSheet).toEqual(expStyles);
 
-    expect(instance.transformStyles(...Object.values(styleSheet))).toMatchSnapshot();
+    expect(instance.transformStyles(Object.values(styleSheet))).toMatchSnapshot();
 
     testSnapshot(raw);
   }

--- a/packages/adapter-typestyle/tests/TypeStyleAesthetic.test.ts
+++ b/packages/adapter-typestyle/tests/TypeStyleAesthetic.test.ts
@@ -45,7 +45,7 @@ describe('TypeStyleAesthetic', () => {
 
     expect(nativeSheet).toEqual(expStyles);
 
-    expect(instance.transformStyles(...Object.values(styleSheet))).toBe(expClassName);
+    expect(instance.transformStyles(Object.values(styleSheet))).toBe(expClassName);
 
     // @ts-ignore
     if (instance.typeStyle._raw) {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,12 @@ To support RTL mode and other frameworks besides React, the core APIs had to sli
 
 - React hooks, HOCs, and types have moved to the new
   [aesthetic-react](https://github.com/milesj/aesthetic/tree/master/packages/react) package.
+- Updated `Aesthetic#transformStyles` to require all styles as an array in the 1st argument, instead
+  of being spread across all arguments.
+
+#### 🚀 Updates
+
+- Added a `cxPropName` option to `Aesthetic`.
 
 ## 3.5.0 - 2019-04-28
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -7,36 +7,61 @@
 Aesthetic is a powerful type-safe, framework agnostic, CSS-in-JS library for styling components,
 whether it be with plain objects, importing style sheets, or simply referencing external class
 names. Simply put, Aesthetic is an abstraction layer for the compilation of styles via third-party
-libraries, all the while providing customizability, theming, and a unified syntax.
+libraries, all the while providing customizability, theming, additional features, and a unified
+syntax.
 
-TODO MOVE TO REACT PACKAGE
+```ts
+import AphroditeAesthetic from 'aesthetic-adapter-aphrodite';
+import { Theme } from './types';
 
-Supports both an HOC and hook styled API!
+const aesthetic = new AphroditeAesthetic<Theme>();
+
+// Register a theme
+aesthetic.registerTheme('light', {
+  unit: 8,
+});
+
+// Define a style sheet
+aesthetic.setStyleSheet('button', ({ unit }) => ({
+  button: {
+    textAlign: 'center',
+    display: 'inline-block',
+    padding: unit,
+  },
+}));
+
+// Parse the styles and generate CSS class names
+const styles = aesthetic.createStyleSheet('button');
+const className = aesthetic.transformStyles(styles.button);
+```
+
+## React
+
+Supports both an HOC and hook styled React API!
 
 ```tsx
 import React from 'react';
-import withStyles, { WithStylesProps } from './withStyles';
-import cx from './cx';
+import useStyles from './useStyles';
 
 export type Props = {
   children: React.ReactNode;
 };
 
-function Button({ children, styles }: Props & WithStylesProps) {
+export default function Button({ children }: Props) {
+  const [styles, cx] = useStyles(({ unit }) => ({
+    button: {
+      textAlign: 'center',
+      display: 'inline-block',
+      padding: unit,
+    },
+  }));
+
   return (
     <button type="button" className={cx(styles.button)}>
       {children}
     </button>
   );
 }
-
-export default withStyles(({ unit }) => ({
-  button: {
-    textAlign: 'center',
-    display: 'inline-block',
-    padding: unit,
-  },
-}))(Button);
 ```
 
 ## Requirements

--- a/packages/core/src/Aesthetic.tsx
+++ b/packages/core/src/Aesthetic.tsx
@@ -14,6 +14,7 @@ import {
 } from './types';
 
 export interface AestheticOptions {
+  cxPropName: string;
   extendable: boolean;
   passThemeProp: boolean;
   pure: boolean;
@@ -47,6 +48,7 @@ export default abstract class Aesthetic<
 
   constructor(options: Partial<AestheticOptions> = {}) {
     this.options = {
+      cxPropName: 'cx',
       extendable: false,
       passThemeProp: false,
       pure: true,
@@ -232,7 +234,7 @@ export default abstract class Aesthetic<
    * Transform the list of style declarations to a list of class name.
    */
   transformStyles = (
-    ...styles: (undefined | false | ClassName | NativeBlock | ParsedBlock)[]
+    styles: (undefined | false | ClassName | NativeBlock | ParsedBlock)[],
   ): ClassName => {
     const classNames: ClassName[] = [];
     const toTransform: (NativeBlock | ParsedBlock)[] = [];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,7 +20,7 @@ export type ThemeName = string;
 
 export type ClassName = string;
 
-export type ClassNameGenerator<N extends object, P extends object | string> = (
+export type ClassNameTransformer<N extends object, P extends object | string> = (
   ...styles: (undefined | false | ClassName | N | P)[]
 ) => ClassName;
 

--- a/packages/core/tests/Aesthetic.test.tsx
+++ b/packages/core/tests/Aesthetic.test.tsx
@@ -42,6 +42,7 @@ describe('Aesthetic', () => {
       });
 
       expect(instance.options).toEqual({
+        cxPropName: 'cx',
         extendable: false,
         passThemeProp: false,
         pure: true,
@@ -477,37 +478,40 @@ describe('Aesthetic', () => {
   describe('transformStyles()', () => {
     it('errors for invalid value', () => {
       expect(() => {
-        instance.transformStyles([true]);
+        instance.transformStyles(
+          // @ts-ignore Allow invalid type
+          [123],
+        );
       }).toThrowErrorMatchingSnapshot();
     });
 
     it('combines strings into a class name', () => {
-      expect(instance.transformStyles('foo', 'bar')).toBe('foo bar');
+      expect(instance.transformStyles(['foo', 'bar'])).toBe('foo bar');
     });
 
     it('calls `transformToClassName` method', () => {
       // @ts-ignore Allow access
       const spy = jest.spyOn(instance, 'transformToClassName');
 
-      instance.transformStyles({ color: 'red' }, { display: 'block' });
+      instance.transformStyles([{ color: 'red' }, { display: 'block' }]);
 
       expect(spy).toHaveBeenCalledWith([{ color: 'red' }, { display: 'block' }]);
     });
 
     it('ignores falsey values', () => {
-      expect(instance.transformStyles(null, false, 0, '', undefined)).toBe('');
+      expect(instance.transformStyles([null, false, 0, '', undefined])).toBe('');
     });
 
     it('strips period prefix', () => {
-      expect(instance.transformStyles('.foo', 'bar .qux')).toBe('foo bar qux');
+      expect(instance.transformStyles(['.foo', 'bar .qux'])).toBe('foo bar qux');
     });
 
     it('handles expression values', () => {
-      expect(instance.transformStyles('foo', true && 'bar', 5 > 10 && 'baz')).toBe('foo bar');
+      expect(instance.transformStyles(['foo', true && 'bar', 5 > 10 && 'baz'])).toBe('foo bar');
     });
 
     it('joins strings', () => {
-      expect(instance.transformStyles('foo', '123', 'bar')).toBe('foo 123 bar');
+      expect(instance.transformStyles(['foo', '123', 'bar'])).toBe('foo 123 bar');
     });
   });
 
@@ -520,7 +524,7 @@ describe('Aesthetic', () => {
 
       const styleSheet = adapter.createStyleSheet('foo');
 
-      expect(adapter.transformStyles(styleSheet.button)).toMatchSnapshot();
+      expect(adapter.transformStyles([styleSheet.button])).toMatchSnapshot();
     });
 
     it('supports Aphrodite', () => {
@@ -531,7 +535,7 @@ describe('Aesthetic', () => {
 
       const styleSheet = adapter.createStyleSheet('foo');
 
-      expect(adapter.transformStyles(styleSheet.button)).toMatchSnapshot();
+      expect(adapter.transformStyles([styleSheet.button])).toMatchSnapshot();
     });
 
     it('supports CSS modules', () => {
@@ -542,7 +546,7 @@ describe('Aesthetic', () => {
 
       const styleSheet = adapter.createStyleSheet('foo');
 
-      expect(adapter.transformStyles(styleSheet.button)).toMatchSnapshot();
+      expect(adapter.transformStyles([styleSheet.button])).toMatchSnapshot();
     });
 
     it('supports Fela', () => {
@@ -557,7 +561,7 @@ describe('Aesthetic', () => {
 
       const styleSheet = adapter.createStyleSheet('foo');
 
-      expect(adapter.transformStyles(styleSheet.button)).toMatchSnapshot();
+      expect(adapter.transformStyles([styleSheet.button])).toMatchSnapshot();
     });
 
     it('supports JSS', () => {
@@ -571,7 +575,7 @@ describe('Aesthetic', () => {
 
       const styleSheet = adapter.createStyleSheet('foo');
 
-      expect(adapter.transformStyles(styleSheet.button)).toMatchSnapshot();
+      expect(adapter.transformStyles([styleSheet.button])).toMatchSnapshot();
     });
 
     it('supports TypeStyle', () => {
@@ -582,7 +586,7 @@ describe('Aesthetic', () => {
 
       const styleSheet = adapter.createStyleSheet('foo');
 
-      expect(adapter.transformStyles(styleSheet.button)).toMatchSnapshot();
+      expect(adapter.transformStyles([styleSheet.button])).toMatchSnapshot();
     });
   });
 });

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -13,3 +13,4 @@
 #### 🚀 Updates
 
 - Added a `cxPropName` option to `withStyles`.
+- Updated `withStyles` HOC to receive the CSS transformer function as a `cx` prop.

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -7,3 +7,9 @@
 #### 💥 Breaking
 
 - Updated `react` requirement to v16.6.
+- **[TS]** Renamed the `WithStylesProps` interface to `WithStylesWrappedProps`.
+- **[TS]** Renamed the `WithThemeProps` interface to `WithThemeWrappedProps`.
+
+#### 🚀 Updates
+
+- Added a `cxPropName` option to `withStyles`.

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SheetMap, StyleName, StyleSheetDefinition } from 'aesthetic';
+import { ClassNameGenerator, SheetMap, StyleName, StyleSheetDefinition } from 'aesthetic';
 import { Omit } from 'utility-types';
 
 export interface WithThemeWrapperProps {
@@ -7,8 +7,8 @@ export interface WithThemeWrapperProps {
   wrappedRef?: React.Ref<any>;
 }
 
-export interface WithThemeProps<Theme> {
-  /** The ref passed through the `wrappedRef` prop. Provided by `withTheme`. */
+export interface WithThemeWrappedProps<Theme> {
+  /** The ref passed by the `wrappedRef` prop. Provided by `withTheme`. */
   ref?: React.Ref<any>;
   /** The theme object. Provided by `withTheme`. */
   theme: Theme;
@@ -26,8 +26,14 @@ export interface WithStylesWrapperProps {
   wrappedRef?: React.Ref<any>;
 }
 
-export interface WithStylesProps<Theme, ParsedBlock> {
-  /** The ref passed through the `wrappedRef` prop. Provided by `withStyles`. */
+export interface WithStylesWrappedProps<
+  Theme,
+  NativeBlock extends object,
+  ParsedBlock extends object | string = NativeBlock
+> {
+  /** Utility function to convert parsed styles into CSS class names. Provided by `withStyles`. */
+  cx: ClassNameGenerator<NativeBlock, ParsedBlock>;
+  /** The ref passed by the `wrappedRef` prop. Provided by `withStyles`. */
   ref?: React.Ref<any>;
   /** The parsed component style sheet in which rulesets can be transformed to class names. Provided by `withStyles`. */
   styles: SheetMap<ParsedBlock>;
@@ -41,6 +47,8 @@ export interface WithStylesState<Props, ParsedBlock> {
 }
 
 export interface WithStylesOptions {
+  /** Name of the prop in which to pass the CSS class name generator function. Provided by `withStyles`. */
+  cxPropName?: string;
   /** Can this component's styles be extended to create a new component. Provided by `withStyles`. */
   extendable?: boolean;
   /** The parent component ID in which to extend styles from. This is usually defined automatically. Provided by `withStyles`. */
@@ -58,7 +66,7 @@ export interface WithStylesOptions {
 export interface StyledComponentClass<Theme, Props> extends React.ComponentClass<Props> {
   displayName: string;
   styleName: StyleName;
-  WrappedComponent: React.ComponentType<Props & WithStylesProps<Theme, any>>;
+  WrappedComponent: React.ComponentType<Props & WithStylesWrappedProps<Theme, any, any>>;
 
   extendStyles<T>(
     styleSheet: StyleSheetDefinition<Theme, T>,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ClassNameGenerator, SheetMap, StyleName, StyleSheetDefinition } from 'aesthetic';
+import { ClassNameTransformer, SheetMap, StyleName, StyleSheetDefinition } from 'aesthetic';
 import { Omit } from 'utility-types';
 
 export interface WithThemeWrapperProps {
@@ -31,8 +31,8 @@ export interface WithStylesWrappedProps<
   NativeBlock extends object,
   ParsedBlock extends object | string = NativeBlock
 > {
-  /** Utility function to convert parsed styles into CSS class names. Provided by `withStyles`. */
-  cx: ClassNameGenerator<NativeBlock, ParsedBlock>;
+  /** Utility function to transform parsed styles into CSS class names. Provided by `withStyles`. */
+  cx: ClassNameTransformer<NativeBlock, ParsedBlock>;
   /** The ref passed by the `wrappedRef` prop. Provided by `withStyles`. */
   ref?: React.Ref<any>;
   /** The parsed component style sheet in which rulesets can be transformed to class names. Provided by `withStyles`. */
@@ -47,7 +47,7 @@ export interface WithStylesState<Props, ParsedBlock> {
 }
 
 export interface WithStylesOptions {
-  /** Name of the prop in which to pass the CSS class name generator function. Provided by `withStyles`. */
+  /** Name of the prop in which to pass the styles to CSS class name transformer function. Provided by `withStyles`. */
   cxPropName?: string;
   /** Can this component's styles be extended to create a new component. Provided by `withStyles`. */
   extendable?: boolean;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -47,7 +47,7 @@ export interface WithStylesState<Props, ParsedBlock> {
 }
 
 export interface WithStylesOptions {
-  /** Name of the prop in which to pass the styles to CSS class name transformer function. Provided by `withStyles`. */
+  /** Name of the prop in which to pass the CSS class name transformer function. Provided by `withStyles`. */
   cxPropName?: string;
   /** Can this component's styles be extended to create a new component. Provided by `withStyles`. */
   extendable?: boolean;

--- a/packages/react/src/useStylesFactory.ts
+++ b/packages/react/src/useStylesFactory.ts
@@ -10,10 +10,12 @@ export default function useStylesFactory<
   NativeBlock extends object,
   ParsedBlock extends object | string = NativeBlock
 >(aesthetic: Aesthetic<Theme, NativeBlock, ParsedBlock>) /* infer */ {
+  type CX = ClassNameGenerator<NativeBlock, ParsedBlock>;
+
   return function useStyles<T>(
     styleSheet: StyleSheetDefinition<Theme, T>,
     customName: string = 'Component',
-  ): [SheetMap<ParsedBlock>, ClassNameGenerator<NativeBlock, ParsedBlock>, string] {
+  ): [SheetMap<ParsedBlock>, CX, string] {
     const [styleName] = useState(() => {
       const name = `${customName}-${uuid()}`;
 
@@ -30,6 +32,9 @@ export default function useStylesFactory<
       aesthetic.flushStyles(styleName);
     }, [styleName]);
 
-    return [sheet, aesthetic.transformStyles, styleName];
+    // Package a CSS generator
+    const cx: CX = (...styles) => aesthetic.transformStyles(styles);
+
+    return [sheet, cx, styleName];
   };
 }

--- a/packages/react/src/useStylesFactory.ts
+++ b/packages/react/src/useStylesFactory.ts
@@ -32,7 +32,7 @@ export default function useStylesFactory<
       aesthetic.flushStyles(styleName);
     }, [styleName]);
 
-    // Create a CSS generator
+    // Create a CSS transformer
     const cx: CX = (...styles) => aesthetic.transformStyles(styles);
 
     return [sheet, cx, styleName];

--- a/packages/react/src/useStylesFactory.ts
+++ b/packages/react/src/useStylesFactory.ts
@@ -1,5 +1,5 @@
 import { useState, useLayoutEffect } from 'react';
-import Aesthetic, { ClassNameGenerator, StyleSheetDefinition, SheetMap } from 'aesthetic';
+import Aesthetic, { ClassNameTransformer, StyleSheetDefinition, SheetMap } from 'aesthetic';
 import uuid from 'uuid/v4';
 
 /**
@@ -10,7 +10,7 @@ export default function useStylesFactory<
   NativeBlock extends object,
   ParsedBlock extends object | string = NativeBlock
 >(aesthetic: Aesthetic<Theme, NativeBlock, ParsedBlock>) /* infer */ {
-  type CX = ClassNameGenerator<NativeBlock, ParsedBlock>;
+  type CX = ClassNameTransformer<NativeBlock, ParsedBlock>;
 
   return function useStyles<T>(
     styleSheet: StyleSheetDefinition<Theme, T>,
@@ -32,7 +32,7 @@ export default function useStylesFactory<
       aesthetic.flushStyles(styleName);
     }, [styleName]);
 
-    // Package a CSS generator
+    // Create a CSS generator
     const cx: CX = (...styles) => aesthetic.transformStyles(styles);
 
     return [sheet, cx, styleName];

--- a/packages/react/src/withStylesFactory.ts
+++ b/packages/react/src/withStylesFactory.ts
@@ -1,12 +1,12 @@
 import React from 'react';
-import Aesthetic, { StyleSheetDefinition } from 'aesthetic';
+import Aesthetic, { ClassNameGenerator, StyleSheetDefinition } from 'aesthetic';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import uuid from 'uuid/v4';
 import { Omit } from 'utility-types';
 import {
   WithStylesOptions,
   WithStylesState,
-  WithStylesProps,
+  WithStylesWrappedProps,
   WithStylesWrapperProps,
   StyledComponentClass,
 } from './types';
@@ -24,6 +24,7 @@ export default function withStylesFactory<
     options: WithStylesOptions = {},
   ) /* infer */ {
     const {
+      cxPropName = aesthetic.options.cxPropName,
       extendable = aesthetic.options.extendable,
       extendFrom = '',
       passThemeProp = aesthetic.options.passThemeProp,
@@ -32,8 +33,12 @@ export default function withStylesFactory<
       themePropName = aesthetic.options.themePropName,
     } = options;
 
+    type CX = ClassNameGenerator<NativeBlock, ParsedBlock>;
+
     return function withStylesComposer<Props extends object = {}>(
-      WrappedComponent: React.ComponentType<Props & WithStylesProps<Theme, ParsedBlock>>,
+      WrappedComponent: React.ComponentType<
+        Props & WithStylesWrappedProps<Theme, NativeBlock, ParsedBlock>
+      >,
     ): StyledComponentClass<Theme, Props & WithStylesWrapperProps> {
       const baseName = WrappedComponent.displayName || WrappedComponent.name;
       const styleName = `${baseName}-${uuid()}`;
@@ -80,9 +85,12 @@ export default function withStylesFactory<
           aesthetic.flushStyles(styleName);
         }
 
+        transformStyles: CX = (...styles) => aesthetic.transformStyles(styles);
+
         render() {
           const { wrappedRef, ...props } = this.props;
-          const extraProps: WithStylesProps<Theme, ParsedBlock> = {
+          const extraProps: WithStylesWrappedProps<Theme, NativeBlock, ParsedBlock> = {
+            [cxPropName as 'cx']: this.transformStyles,
             [stylesPropName as 'styles']: this.state.styles,
             ref: wrappedRef,
           };

--- a/packages/react/src/withStylesFactory.ts
+++ b/packages/react/src/withStylesFactory.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import Aesthetic, { ClassNameGenerator, StyleSheetDefinition } from 'aesthetic';
+import Aesthetic, { ClassNameTransformer, StyleSheetDefinition } from 'aesthetic';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import uuid from 'uuid/v4';
 import { Omit } from 'utility-types';
@@ -33,7 +33,7 @@ export default function withStylesFactory<
       themePropName = aesthetic.options.themePropName,
     } = options;
 
-    type CX = ClassNameGenerator<NativeBlock, ParsedBlock>;
+    type CX = ClassNameTransformer<NativeBlock, ParsedBlock>;
 
     return function withStylesComposer<Props extends object = {}>(
       WrappedComponent: React.ComponentType<

--- a/packages/react/src/withThemeFactory.ts
+++ b/packages/react/src/withThemeFactory.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import Aesthetic from 'aesthetic';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import { WithThemeOptions, WithThemeProps, WithThemeWrapperProps } from './types';
+import { WithThemeOptions, WithThemeWrappedProps, WithThemeWrapperProps } from './types';
 
 /**
  * Wrap a React component with an HOC that injects the current theme object as a prop.
@@ -18,7 +18,7 @@ export default function withThemeFactory<
     } = options;
 
     return function withThemeComposer<Props extends object = {}>(
-      WrappedComponent: React.ComponentType<Props & WithThemeProps<Theme>>,
+      WrappedComponent: React.ComponentType<Props & WithThemeWrappedProps<Theme>>,
     ): React.ComponentClass<Props & WithThemeWrapperProps> {
       const baseName = WrappedComponent.displayName || WrappedComponent.name;
       const Component = pure ? React.PureComponent : React.Component;
@@ -30,7 +30,7 @@ export default function withThemeFactory<
 
         render() {
           const { wrappedRef, ...props } = this.props;
-          const extraProps: WithThemeProps<Theme> = {
+          const extraProps: WithThemeWrappedProps<Theme> = {
             [themePropName as 'theme']: aesthetic.getTheme(),
             ref: wrappedRef,
           };

--- a/packages/react/tests/withStylesFactory.test.tsx
+++ b/packages/react/tests/withStylesFactory.test.tsx
@@ -176,20 +176,23 @@ describe('withStylesFactory()', () => {
     });
   });
 
-  it('can customize props with the withStyles options', () => {
+  it('can customize props with options', () => {
     aesthetic.options.passThemeProp = true;
 
     const Wrapped = withStyles(() => TEST_STATEMENT, {
+      cxPropName: 'css',
       stylesPropName: 'styleSheet',
       themePropName: 'someThemeNameHere',
     })(StylesComponent);
     const wrapper = shallow(<Wrapped />);
 
+    expect(wrapper.prop('css')).toBeDefined();
     expect(wrapper.prop('styleSheet')).toBeDefined();
     expect(wrapper.prop('someThemeNameHere')).toBeDefined();
   });
 
   it('can customize props with the options through the `Aesthetic` instance', () => {
+    aesthetic.options.cxPropName = 'css';
     aesthetic.options.stylesPropName = 'styleSheet';
     aesthetic.options.themePropName = 'someThemeNameHere';
     aesthetic.options.passThemeProp = true;
@@ -197,6 +200,7 @@ describe('withStylesFactory()', () => {
     const Wrapped = withStyles(() => TEST_STATEMENT)(StylesComponent);
     const wrapper = shallow(<Wrapped />);
 
+    expect(wrapper.prop('css')).toBeDefined();
     expect(wrapper.prop('styleSheet')).toBeDefined();
     expect(wrapper.prop('someThemeNameHere')).toBeDefined();
   });

--- a/packages/react/tests/withStylesFactory.test.tsx
+++ b/packages/react/tests/withStylesFactory.test.tsx
@@ -153,6 +153,13 @@ describe('withStylesFactory()', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
+  it('inherits a function to generate CSS class names', () => {
+    const Wrapped = withStyles(() => ({}))(BaseComponent);
+    const wrapper = shallow(<Wrapped />);
+
+    expect(typeof wrapper.prop('cx')).toBe('function');
+  });
+
   it('inherits theme from Aesthetic options', () => {
     function ThemeComponent() {
       return <div />;
@@ -233,5 +240,16 @@ describe('withStylesFactory()', () => {
 
     expect(refInstance).not.toBeNull();
     expect(refInstance!.constructor.name).toBe('RefComponent');
+  });
+
+  it('can transform class names', () => {
+    function Component({ cx, styles }: any) {
+      return <div className={cx(styles.header, styles.footer)} />;
+    }
+
+    const Wrapped = withStyles(() => TEST_STATEMENT)(Component);
+    const wrapper = shallow(<Wrapped />).dive();
+
+    expect(wrapper.prop('className')).toBe('class-0 class-1');
   });
 });

--- a/tests/bundle.tsx
+++ b/tests/bundle.tsx
@@ -8,7 +8,7 @@ import { create as createJSS } from 'jss';
 // @ts-ignore
 import jssPreset from 'jss-preset-default';
 import { TypeStyle } from 'typestyle';
-import Aesthetic, { WithStylesProps } from 'aesthetic';
+import Aesthetic, { WithStylesWrappedProps } from 'aesthetic';
 import AphroditeAesthetic from 'aesthetic-adapter-aphrodite';
 import FelaAesthetic from 'aesthetic-adapter-fela';
 import JSSAesthetic from 'aesthetic-adapter-jss';
@@ -131,7 +131,7 @@ function createHocComponent(aesthetic: Aesthetic<Theme, any, any>) {
     styles,
     theme,
     primary = false,
-  }: HocProps & WithStylesProps<Theme, any>) {
+  }: HocProps & WithStylesWrappedProps<Theme, any, any>) {
     const className = aesthetic.transformStyles(styles.button, primary && styles.button__primary);
 
     console.log(aesthetic.constructor.name, 'HocButton', { styles, theme, className });

--- a/tests/typings.tsx
+++ b/tests/typings.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ClassNameAesthetic, ComponentBlock, WithStylesProps } from 'aesthetic';
+import { ClassNameAesthetic, ComponentBlock, WithStylesWrappedProps } from 'aesthetic';
 
 type Theme = {
   unit: number;
@@ -25,7 +25,7 @@ aesthetic.extendTheme('classic', 'default', {
   color: 'white',
 });
 
-const Comp: React.SFC<Props & WithStylesProps<Theme, string>> = props => {
+const Comp: React.SFC<Props & WithStylesWrappedProps<Theme, string, string>> = props => {
   return <div className={aesthetic.transformStyles(props.styles.button)} />;
 };
 


### PR DESCRIPTION
To support RTL and advanced features in the future, the process in which we transform styles into CSS class names had to change. In previous versions, the `cx` function was factoried outside of a component, in which it has *0* context into the rendering cycle (for HOCs only). This new approach passes the `cx` function down as a prop.

- [x] Update code
- [x] Update docs & changelogs
- [x] Update migration guide