### PR TITLE
Add purging of global styles

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,0 @@
-
-workspaces-experimental true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,5 @@
 - [aesthetic-adapter-fela](./packages/adapter-fela/CHANGELOG.md)
 - [aesthetic-adapter-jss](./packages/adapter-jss/CHANGELOG.md)
 - [aesthetic-adapter-typestyle](./packages/adapter-typestyle/CHANGELOG.md)
+- [aesthetic-react](./packages/react/CHANGELOG.md)
+- [aesthetic-utils](./packages/utils/CHANGELOG.md)

--- a/docs/integrations/react.md
+++ b/docs/integrations/react.md
@@ -208,9 +208,9 @@ class Search extends React.Component<{}, { input: string }> {
 
 ### ThemeProvider
 
-The `ThemeProvider` provides a layer to change the theme for a specific region of the page. To
-properly function, the provider _must_ contain all components that rely on Aesthetic styling, and
-must be passed an `Aesthetic` instance.
+The `ThemeProvider` provides a layer to change the theme for a specific region of the page. The
+provider _must_ contain all components that rely on Aesthetic styling, and must be passed an
+`Aesthetic` instance.
 
 ```tsx
 import { ThemeProvider } from 'aesthetic-react';
@@ -232,6 +232,16 @@ By default the `theme` option on the Aesthetic instance will be used as the targ
 ```
 
 > Do note that global styles for all active themes in the current page may collide.
+
+By default, multiple providers can be rendered at the same time, which results in global styles from
+all themes also being rendered. If you'd prefer to purge the previous global styles when changing to
+a new theme (preferrably at the root), set the `propagate` prop.
+
+```tsx
+<ThemeProvider aesthetic={aesthetic} name="dark" propagate>
+  <App />
+</ThemeProvider>
+```
 
 ## Accessing The Theme
 

--- a/packages/adapter-aphrodite/src/AphroditeAesthetic.ts
+++ b/packages/adapter-aphrodite/src/AphroditeAesthetic.ts
@@ -1,4 +1,12 @@
-import Aesthetic, { AestheticOptions, ClassName, Ruleset, Sheet, SheetMap } from 'aesthetic';
+import Aesthetic, {
+  AestheticOptions,
+  ClassName,
+  Ruleset,
+  Sheet,
+  SheetMap,
+  StyleName,
+  GLOBAL_STYLE_NAME,
+} from 'aesthetic';
 import { getStyleElements, purgeStyles } from 'aesthetic-utils';
 // @ts-ignore flushToStyleTag is not typed
 import { StyleSheet as Aphrodite, Extension, flushToStyleTag } from 'aphrodite';
@@ -52,8 +60,8 @@ export default class AphroditeAesthetic<Theme extends object> extends Aesthetic<
     return this.aphrodite.StyleSheet.create(styleSheet) as SheetMap<ParsedBlock>;
   }
 
-  purgeStyles() {
-    purgeStyles(getStyleElements('data-aphrodite'));
+  purgeStyles(styleName?: StyleName) {
+    purgeStyles(getStyleElements('data-aphrodite'), styleName === GLOBAL_STYLE_NAME);
   }
 
   transformToClassName(styles: ParsedBlock[]): ClassName {

--- a/packages/adapter-aphrodite/tests/AphroditeAesthetic.test.ts
+++ b/packages/adapter-aphrodite/tests/AphroditeAesthetic.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jest/expect-expect */
 
 import { StyleSheetTestUtils } from 'aphrodite';
+import { GLOBAL_STYLE_NAME } from 'aesthetic';
 import {
   cleanupStyleElements,
   getFlushedStyles,
@@ -51,18 +52,8 @@ describe('AphroditeAesthetic', () => {
         );
       });
 
-      it('flushes and purges styles from the DOM', () => {
-        const styles = { test: { display: 'block' } };
-
-        renderAndExpect(instance, styles, styles, { dir });
-
-        instance.purgeStyles();
-
-        expect(getFlushedStyles()).toMatchSnapshot();
-      });
-
       describe('global sheet', () => {
-        it('handles globals', () => {
+        it('flushes and purges styles from the DOM', () => {
           renderAndExpect(
             instance,
             SYNTAX_GLOBAL,
@@ -75,11 +66,27 @@ describe('AphroditeAesthetic', () => {
                   ':hover': {
                     color: 'darkred',
                   },
+                  ':focus': {
+                    color: 'lightred',
+                  },
+                },
+                '*ul': {
+                  margin: 0,
+                  '> li': {
+                    margin: 0,
+                  },
+                  '@media (max-width: 500px)': {
+                    margin: 20,
+                  },
                 },
               },
             },
             { dir, global: true },
           );
+
+          instance.purgeStyles(GLOBAL_STYLE_NAME);
+
+          expect(getFlushedStyles()).toMatchSnapshot();
         });
 
         it('handles @font-face', () => {
@@ -117,6 +124,16 @@ describe('AphroditeAesthetic', () => {
       });
 
       describe('style sheet', () => {
+        it('flushes and purges styles from the DOM', () => {
+          const styles = { test: { display: 'block' } };
+
+          renderAndExpect(instance, styles, styles, { dir });
+
+          instance.purgeStyles();
+
+          expect(getFlushedStyles()).toMatchSnapshot();
+        });
+
         it('converts unified syntax to native syntax and transforms to a class name', () => {
           instance.fontFaces.Roboto = [FONT_ROBOTO_FLAT_SRC as any];
           instance.keyframes.fade = KEYFRAME_FADE;

--- a/packages/adapter-aphrodite/tests/AphroditeAesthetic.test.ts
+++ b/packages/adapter-aphrodite/tests/AphroditeAesthetic.test.ts
@@ -53,7 +53,7 @@ describe('AphroditeAesthetic', () => {
       });
 
       describe('global sheet', () => {
-        it('flushes and purges styles from the DOM', () => {
+        it('flushes and purges global styles from the DOM', () => {
           renderAndExpect(
             instance,
             SYNTAX_GLOBAL,
@@ -124,7 +124,7 @@ describe('AphroditeAesthetic', () => {
       });
 
       describe('style sheet', () => {
-        it('flushes and purges styles from the DOM', () => {
+        it('flushes and purges all styles from the DOM', () => {
           const styles = { test: { display: 'block' } };
 
           renderAndExpect(instance, styles, styles, { dir });

--- a/packages/adapter-aphrodite/tests/__snapshots__/AphroditeAesthetic.test.ts.snap
+++ b/packages/adapter-aphrodite/tests/__snapshots__/AphroditeAesthetic.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AphroditeAesthetic LTR global sheet flushes and purges styles from the DOM 1`] = `
+exports[`AphroditeAesthetic LTR global sheet flushes and purges global styles from the DOM 1`] = `
 "body {margin: 0px !important;}
 html {height: 100% !important;}
 a {color: red !important;}
@@ -11,9 +11,9 @@ ul > li {margin: 0px !important;}
 @media (max-width: 500px) {ul {margin: 20px !important;}}"
 `;
 
-exports[`AphroditeAesthetic LTR global sheet flushes and purges styles from the DOM 2`] = `"globals_5ijnvn"`;
+exports[`AphroditeAesthetic LTR global sheet flushes and purges global styles from the DOM 2`] = `"globals_5ijnvn"`;
 
-exports[`AphroditeAesthetic LTR global sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`AphroditeAesthetic LTR global sheet flushes and purges global styles from the DOM 3`] = `""`;
 
 exports[`AphroditeAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; src: local('Robo'), url('fonts/Roboto.woff2') format('woff2'), url('fonts/Roboto.ttf') format('truetype');}
@@ -29,11 +29,11 @@ exports[`AphroditeAesthetic LTR style sheet converts unified syntax to native sy
 
 exports[`AphroditeAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button_1dmte4q"`;
 
-exports[`AphroditeAesthetic LTR style sheet flushes and purges styles from the DOM 1`] = `".test_uhlm2 {display: block !important;}"`;
+exports[`AphroditeAesthetic LTR style sheet flushes and purges all styles from the DOM 1`] = `".test_uhlm2 {display: block !important;}"`;
 
-exports[`AphroditeAesthetic LTR style sheet flushes and purges styles from the DOM 2`] = `"test_uhlm2"`;
+exports[`AphroditeAesthetic LTR style sheet flushes and purges all styles from the DOM 2`] = `"test_uhlm2"`;
 
-exports[`AphroditeAesthetic LTR style sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`AphroditeAesthetic LTR style sheet flushes and purges all styles from the DOM 3`] = `""`;
 
 exports[`AphroditeAesthetic LTR style sheet handles @media 1`] = `
 ".media_1jcccqt {color: red !important; padding-left: 10px !important;}
@@ -121,7 +121,7 @@ exports[`AphroditeAesthetic LTR style sheet handles raw CSS 1`] = `
 
 exports[`AphroditeAesthetic LTR style sheet handles raw CSS 2`] = `""`;
 
-exports[`AphroditeAesthetic RTL global sheet flushes and purges styles from the DOM 1`] = `
+exports[`AphroditeAesthetic RTL global sheet flushes and purges global styles from the DOM 1`] = `
 "body {margin: 0px !important;}
 html {height: 100% !important;}
 a {color: red !important;}
@@ -132,9 +132,9 @@ ul > li {margin: 0px !important;}
 @media (max-width: 500px) {ul {margin: 20px !important;}}"
 `;
 
-exports[`AphroditeAesthetic RTL global sheet flushes and purges styles from the DOM 2`] = `"globals_5ijnvn"`;
+exports[`AphroditeAesthetic RTL global sheet flushes and purges global styles from the DOM 2`] = `"globals_5ijnvn"`;
 
-exports[`AphroditeAesthetic RTL global sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`AphroditeAesthetic RTL global sheet flushes and purges global styles from the DOM 3`] = `""`;
 
 exports[`AphroditeAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; src: local('Robo'), url('fonts/Roboto.woff2') format('woff2'), url('fonts/Roboto.ttf') format('truetype');}
@@ -150,11 +150,11 @@ exports[`AphroditeAesthetic RTL style sheet converts unified syntax to native sy
 
 exports[`AphroditeAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button_pvvr1m"`;
 
-exports[`AphroditeAesthetic RTL style sheet flushes and purges styles from the DOM 1`] = `".test_uhlm2 {display: block !important;}"`;
+exports[`AphroditeAesthetic RTL style sheet flushes and purges all styles from the DOM 1`] = `".test_uhlm2 {display: block !important;}"`;
 
-exports[`AphroditeAesthetic RTL style sheet flushes and purges styles from the DOM 2`] = `"test_uhlm2"`;
+exports[`AphroditeAesthetic RTL style sheet flushes and purges all styles from the DOM 2`] = `"test_uhlm2"`;
 
-exports[`AphroditeAesthetic RTL style sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`AphroditeAesthetic RTL style sheet flushes and purges all styles from the DOM 3`] = `""`;
 
 exports[`AphroditeAesthetic RTL style sheet handles @media 1`] = `
 ".media_1xdaj1a {color: red !important; padding-right: 10px !important;}

--- a/packages/adapter-aphrodite/tests/__snapshots__/AphroditeAesthetic.test.ts.snap
+++ b/packages/adapter-aphrodite/tests/__snapshots__/AphroditeAesthetic.test.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AphroditeAesthetic LTR flushes and purges styles from the DOM 1`] = `".test_uhlm2 {display: block !important;}"`;
-
-exports[`AphroditeAesthetic LTR flushes and purges styles from the DOM 2`] = `"test_uhlm2"`;
-
-exports[`AphroditeAesthetic LTR flushes and purges styles from the DOM 3`] = `""`;
-
-exports[`AphroditeAesthetic LTR global sheet handles globals 1`] = `
+exports[`AphroditeAesthetic LTR global sheet flushes and purges styles from the DOM 1`] = `
 "body {margin: 0px !important;}
 html {height: 100% !important;}
 a {color: red !important;}
-a:hover {color: darkred !important;}"
+a:hover {color: darkred !important;}
+a:focus {color: lightred !important;}
+ul {margin: 0px !important;}
+ul > li {margin: 0px !important;}
+@media (max-width: 500px) {ul {margin: 20px !important;}}"
 `;
 
-exports[`AphroditeAesthetic LTR global sheet handles globals 2`] = `"globals_vyedjg"`;
+exports[`AphroditeAesthetic LTR global sheet flushes and purges styles from the DOM 2`] = `"globals_5ijnvn"`;
+
+exports[`AphroditeAesthetic LTR global sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`AphroditeAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; src: local('Robo'), url('fonts/Roboto.woff2') format('woff2'), url('fonts/Roboto.ttf') format('truetype');}
@@ -28,6 +28,12 @@ exports[`AphroditeAesthetic LTR style sheet converts unified syntax to native sy
 `;
 
 exports[`AphroditeAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button_1dmte4q"`;
+
+exports[`AphroditeAesthetic LTR style sheet flushes and purges styles from the DOM 1`] = `".test_uhlm2 {display: block !important;}"`;
+
+exports[`AphroditeAesthetic LTR style sheet flushes and purges styles from the DOM 2`] = `"test_uhlm2"`;
+
+exports[`AphroditeAesthetic LTR style sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`AphroditeAesthetic LTR style sheet handles @media 1`] = `
 ".media_1jcccqt {color: red !important; padding-left: 10px !important;}
@@ -115,20 +121,20 @@ exports[`AphroditeAesthetic LTR style sheet handles raw CSS 1`] = `
 
 exports[`AphroditeAesthetic LTR style sheet handles raw CSS 2`] = `""`;
 
-exports[`AphroditeAesthetic RTL flushes and purges styles from the DOM 1`] = `".test_uhlm2 {display: block !important;}"`;
-
-exports[`AphroditeAesthetic RTL flushes and purges styles from the DOM 2`] = `"test_uhlm2"`;
-
-exports[`AphroditeAesthetic RTL flushes and purges styles from the DOM 3`] = `""`;
-
-exports[`AphroditeAesthetic RTL global sheet handles globals 1`] = `
+exports[`AphroditeAesthetic RTL global sheet flushes and purges styles from the DOM 1`] = `
 "body {margin: 0px !important;}
 html {height: 100% !important;}
 a {color: red !important;}
-a:hover {color: darkred !important;}"
+a:hover {color: darkred !important;}
+a:focus {color: lightred !important;}
+ul {margin: 0px !important;}
+ul > li {margin: 0px !important;}
+@media (max-width: 500px) {ul {margin: 20px !important;}}"
 `;
 
-exports[`AphroditeAesthetic RTL global sheet handles globals 2`] = `"globals_vyedjg"`;
+exports[`AphroditeAesthetic RTL global sheet flushes and purges styles from the DOM 2`] = `"globals_5ijnvn"`;
+
+exports[`AphroditeAesthetic RTL global sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`AphroditeAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; src: local('Robo'), url('fonts/Roboto.woff2') format('woff2'), url('fonts/Roboto.ttf') format('truetype');}
@@ -143,6 +149,12 @@ exports[`AphroditeAesthetic RTL style sheet converts unified syntax to native sy
 `;
 
 exports[`AphroditeAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button_pvvr1m"`;
+
+exports[`AphroditeAesthetic RTL style sheet flushes and purges styles from the DOM 1`] = `".test_uhlm2 {display: block !important;}"`;
+
+exports[`AphroditeAesthetic RTL style sheet flushes and purges styles from the DOM 2`] = `"test_uhlm2"`;
+
+exports[`AphroditeAesthetic RTL style sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`AphroditeAesthetic RTL style sheet handles @media 1`] = `
 ".media_1xdaj1a {color: red !important; padding-right: 10px !important;}

--- a/packages/adapter-fela/src/FelaAesthetic.ts
+++ b/packages/adapter-fela/src/FelaAesthetic.ts
@@ -1,4 +1,11 @@
-import Aesthetic, { AestheticOptions, ClassName, Ruleset, Sheet } from 'aesthetic';
+import Aesthetic, {
+  AestheticOptions,
+  ClassName,
+  Ruleset,
+  Sheet,
+  StyleName,
+  GLOBAL_STYLE_NAME,
+} from 'aesthetic';
 import { getStyleElements, purgeStyles } from 'aesthetic-utils';
 import { combineRules, IRenderer } from 'fela';
 import { render } from 'fela-dom';
@@ -40,8 +47,8 @@ export default class FelaAesthetic<Theme extends object> extends Aesthetic<
     return this.fela.renderRule(combineRules(...styles.map(style => () => style)), {});
   }
 
-  purgeStyles() {
-    purgeStyles(getStyleElements('data-fela-type'));
+  purgeStyles(styleName?: StyleName) {
+    purgeStyles(getStyleElements('data-fela-type'), styleName === GLOBAL_STYLE_NAME);
   }
 
   // http://fela.js.org/docs/api/fela/Renderer.html

--- a/packages/adapter-fela/tests/FelaAesthetic.test.ts
+++ b/packages/adapter-fela/tests/FelaAesthetic.test.ts
@@ -57,7 +57,7 @@ describe('FelaAesthetic', () => {
       });
 
       describe('global sheet', () => {
-        it('flushes and purges styles from the DOM', () => {
+        it('flushes and purges global styles from the DOM', () => {
           renderAndExpect(instance, SYNTAX_GLOBAL, {}, { dir, global: true });
 
           instance.purgeStyles(GLOBAL_STYLE_NAME);
@@ -111,7 +111,7 @@ describe('FelaAesthetic', () => {
       });
 
       describe('style sheet', () => {
-        it('flushes and purges styles from the DOM', () => {
+        it('flushes and purges all styles from the DOM', () => {
           const styles = { test: { display: 'block' } };
 
           renderAndExpect(instance, styles, styles, { dir });

--- a/packages/adapter-fela/tests/FelaAesthetic.test.ts
+++ b/packages/adapter-fela/tests/FelaAesthetic.test.ts
@@ -2,6 +2,7 @@
 
 import { createRenderer } from 'fela';
 import webPreset from 'fela-preset-web';
+import { GLOBAL_STYLE_NAME } from 'aesthetic';
 import {
   cleanupStyleElements,
   getFlushedStyles,
@@ -55,19 +56,13 @@ describe('FelaAesthetic', () => {
         expect(instance.transformStyles([{ margin: 0 }, { padding: 2 }], { dir })).toBe('a b');
       });
 
-      it('flushes and purges styles from the DOM', () => {
-        const styles = { test: { display: 'block' } };
-
-        renderAndExpect(instance, styles, styles, { dir });
-
-        instance.purgeStyles();
-
-        expect(getFlushedStyles()).toMatchSnapshot();
-      });
-
       describe('global sheet', () => {
-        it('handles globals', () => {
+        it('flushes and purges styles from the DOM', () => {
           renderAndExpect(instance, SYNTAX_GLOBAL, {}, { dir, global: true });
+
+          instance.purgeStyles(GLOBAL_STYLE_NAME);
+
+          expect(getFlushedStyles()).toMatchSnapshot();
         });
 
         it('handles @font-face', () => {
@@ -116,6 +111,16 @@ describe('FelaAesthetic', () => {
       });
 
       describe('style sheet', () => {
+        it('flushes and purges styles from the DOM', () => {
+          const styles = { test: { display: 'block' } };
+
+          renderAndExpect(instance, styles, styles, { dir });
+
+          instance.purgeStyles();
+
+          expect(getFlushedStyles()).toMatchSnapshot();
+        });
+
         it('converts unified syntax to native syntax and transforms to a class name', () => {
           instance.fela.renderFont('Roboto', FONT_ROBOTO.srcPaths, FONT_ROBOTO);
 

--- a/packages/adapter-fela/tests/__snapshots__/FelaAesthetic.test.ts.snap
+++ b/packages/adapter-fela/tests/__snapshots__/FelaAesthetic.test.ts.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FelaAesthetic LTR global sheet flushes and purges styles from the DOM 1`] = `
+exports[`FelaAesthetic LTR global sheet flushes and purges global styles from the DOM 1`] = `
 "body {margin: 0;}
 html {height: 100%;}
 a {color: red;}
 ul {margin: 0;}"
 `;
 
-exports[`FelaAesthetic LTR global sheet flushes and purges styles from the DOM 2`] = `""`;
+exports[`FelaAesthetic LTR global sheet flushes and purges global styles from the DOM 2`] = `""`;
 
-exports[`FelaAesthetic LTR global sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`FelaAesthetic LTR global sheet flushes and purges global styles from the DOM 3`] = `""`;
 
 exports[`FelaAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: \\"Roboto\\"; font-style: normal; font-weight: normal; src: url('fonts/Roboto.woff2') format('woff2'),url('fonts/Roboto.ttf') format('truetype');}
@@ -53,11 +53,11 @@ exports[`FelaAesthetic LTR style sheet converts unified syntax to native syntax 
 
 exports[`FelaAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"a b c d e f g h i j k l m n o p q r s t u v w x"`;
 
-exports[`FelaAesthetic LTR style sheet flushes and purges styles from the DOM 1`] = `".a {display: block;}"`;
+exports[`FelaAesthetic LTR style sheet flushes and purges all styles from the DOM 1`] = `".a {display: block;}"`;
 
-exports[`FelaAesthetic LTR style sheet flushes and purges styles from the DOM 2`] = `"a"`;
+exports[`FelaAesthetic LTR style sheet flushes and purges all styles from the DOM 2`] = `"a"`;
 
-exports[`FelaAesthetic LTR style sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`FelaAesthetic LTR style sheet flushes and purges all styles from the DOM 3`] = `""`;
 
 exports[`FelaAesthetic LTR style sheet handles @fallbacks 1`] = `
 ".a {background: linear-gradient(...);}
@@ -189,16 +189,16 @@ exports[`FelaAesthetic LTR style sheet handles raw CSS 1`] = `
 
 exports[`FelaAesthetic LTR style sheet handles raw CSS 2`] = `""`;
 
-exports[`FelaAesthetic RTL global sheet flushes and purges styles from the DOM 1`] = `
+exports[`FelaAesthetic RTL global sheet flushes and purges global styles from the DOM 1`] = `
 "body {margin: 0;}
 html {height: 100%;}
 a {color: red;}
 ul {margin: 0;}"
 `;
 
-exports[`FelaAesthetic RTL global sheet flushes and purges styles from the DOM 2`] = `""`;
+exports[`FelaAesthetic RTL global sheet flushes and purges global styles from the DOM 2`] = `""`;
 
-exports[`FelaAesthetic RTL global sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`FelaAesthetic RTL global sheet flushes and purges global styles from the DOM 3`] = `""`;
 
 exports[`FelaAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: \\"Roboto\\"; font-style: normal; font-weight: normal; src: url('fonts/Roboto.woff2') format('woff2'),url('fonts/Roboto.ttf') format('truetype');}
@@ -242,11 +242,11 @@ exports[`FelaAesthetic RTL style sheet converts unified syntax to native syntax 
 
 exports[`FelaAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"a b c d e f g h i j k l m n o p q r s t u v w x"`;
 
-exports[`FelaAesthetic RTL style sheet flushes and purges styles from the DOM 1`] = `".a {display: block;}"`;
+exports[`FelaAesthetic RTL style sheet flushes and purges all styles from the DOM 1`] = `".a {display: block;}"`;
 
-exports[`FelaAesthetic RTL style sheet flushes and purges styles from the DOM 2`] = `"a"`;
+exports[`FelaAesthetic RTL style sheet flushes and purges all styles from the DOM 2`] = `"a"`;
 
-exports[`FelaAesthetic RTL style sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`FelaAesthetic RTL style sheet flushes and purges all styles from the DOM 3`] = `""`;
 
 exports[`FelaAesthetic RTL style sheet handles @fallbacks 1`] = `
 ".a {background: linear-gradient(...);}

--- a/packages/adapter-fela/tests/__snapshots__/FelaAesthetic.test.ts.snap
+++ b/packages/adapter-fela/tests/__snapshots__/FelaAesthetic.test.ts.snap
@@ -1,18 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FelaAesthetic LTR flushes and purges styles from the DOM 1`] = `".a {display: block;}"`;
-
-exports[`FelaAesthetic LTR flushes and purges styles from the DOM 2`] = `"a"`;
-
-exports[`FelaAesthetic LTR flushes and purges styles from the DOM 3`] = `""`;
-
-exports[`FelaAesthetic LTR global sheet handles globals 1`] = `
+exports[`FelaAesthetic LTR global sheet flushes and purges styles from the DOM 1`] = `
 "body {margin: 0;}
 html {height: 100%;}
-a {color: red;}"
+a {color: red;}
+ul {margin: 0;}"
 `;
 
-exports[`FelaAesthetic LTR global sheet handles globals 2`] = `""`;
+exports[`FelaAesthetic LTR global sheet flushes and purges styles from the DOM 2`] = `""`;
+
+exports[`FelaAesthetic LTR global sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`FelaAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: \\"Roboto\\"; font-style: normal; font-weight: normal; src: url('fonts/Roboto.woff2') format('woff2'),url('fonts/Roboto.ttf') format('truetype');}
@@ -55,6 +52,12 @@ exports[`FelaAesthetic LTR style sheet converts unified syntax to native syntax 
 `;
 
 exports[`FelaAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"a b c d e f g h i j k l m n o p q r s t u v w x"`;
+
+exports[`FelaAesthetic LTR style sheet flushes and purges styles from the DOM 1`] = `".a {display: block;}"`;
+
+exports[`FelaAesthetic LTR style sheet flushes and purges styles from the DOM 2`] = `"a"`;
+
+exports[`FelaAesthetic LTR style sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`FelaAesthetic LTR style sheet handles @fallbacks 1`] = `
 ".a {background: linear-gradient(...);}
@@ -186,19 +189,16 @@ exports[`FelaAesthetic LTR style sheet handles raw CSS 1`] = `
 
 exports[`FelaAesthetic LTR style sheet handles raw CSS 2`] = `""`;
 
-exports[`FelaAesthetic RTL flushes and purges styles from the DOM 1`] = `".a {display: block;}"`;
-
-exports[`FelaAesthetic RTL flushes and purges styles from the DOM 2`] = `"a"`;
-
-exports[`FelaAesthetic RTL flushes and purges styles from the DOM 3`] = `""`;
-
-exports[`FelaAesthetic RTL global sheet handles globals 1`] = `
+exports[`FelaAesthetic RTL global sheet flushes and purges styles from the DOM 1`] = `
 "body {margin: 0;}
 html {height: 100%;}
-a {color: red;}"
+a {color: red;}
+ul {margin: 0;}"
 `;
 
-exports[`FelaAesthetic RTL global sheet handles globals 2`] = `""`;
+exports[`FelaAesthetic RTL global sheet flushes and purges styles from the DOM 2`] = `""`;
+
+exports[`FelaAesthetic RTL global sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`FelaAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: \\"Roboto\\"; font-style: normal; font-weight: normal; src: url('fonts/Roboto.woff2') format('woff2'),url('fonts/Roboto.ttf') format('truetype');}
@@ -241,6 +241,12 @@ exports[`FelaAesthetic RTL style sheet converts unified syntax to native syntax 
 `;
 
 exports[`FelaAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"a b c d e f g h i j k l m n o p q r s t u v w x"`;
+
+exports[`FelaAesthetic RTL style sheet flushes and purges styles from the DOM 1`] = `".a {display: block;}"`;
+
+exports[`FelaAesthetic RTL style sheet flushes and purges styles from the DOM 2`] = `"a"`;
+
+exports[`FelaAesthetic RTL style sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`FelaAesthetic RTL style sheet handles @fallbacks 1`] = `
 ".a {background: linear-gradient(...);}

--- a/packages/adapter-jss/src/JSSAesthetic.ts
+++ b/packages/adapter-jss/src/JSSAesthetic.ts
@@ -63,12 +63,20 @@ export default class JSSAesthetic<Theme extends object> extends Aesthetic<
     return this.sheets[styleName].classes;
   }
 
-  purgeStyles() {
-    Object.values(this.sheets).forEach(sheet => {
-      sheet.detach();
-    });
+  purgeStyles(styleName?: StyleName) {
+    if (styleName) {
+      if (this.sheets[styleName]) {
+        this.sheets[styleName].detach();
 
-    this.sheets = {};
+        delete this.sheets[styleName];
+      }
+    } else {
+      Object.values(this.sheets).forEach(sheet => {
+        sheet.detach();
+      });
+
+      this.sheets = {};
+    }
   }
 
   transformToClassName(styles: ParsedBlock[]): ClassName {

--- a/packages/adapter-jss/tests/JSSAesthetic.test.ts
+++ b/packages/adapter-jss/tests/JSSAesthetic.test.ts
@@ -3,6 +3,7 @@
 import { create } from 'jss';
 // @ts-ignore
 import preset from 'jss-preset-default';
+import { GLOBAL_STYLE_NAME } from 'aesthetic';
 import {
   cleanupStyleElements,
   getFlushedStyles,
@@ -69,18 +70,8 @@ describe('JSSAesthetic', () => {
         expect(getFlushedStyles()).toMatchSnapshot();
       });
 
-      it('flushes and purges styles from the DOM', () => {
-        const styles = { test: { display: 'block' } };
-
-        renderAndExpect(instance, styles, styles, { dir });
-
-        instance.purgeStyles();
-
-        expect(getFlushedStyles()).toMatchSnapshot();
-      });
-
       describe('global sheet', () => {
-        it('handles globals', () => {
+        it('flushes and purges styles from the DOM', () => {
           renderAndExpect(
             instance,
             SYNTAX_GLOBAL,
@@ -93,11 +84,27 @@ describe('JSSAesthetic', () => {
                   '&:hover': {
                     color: 'darkred',
                   },
+                  '&:focus': {
+                    color: 'lightred',
+                  },
+                },
+                ul: {
+                  margin: 0,
+                  '&> li': {
+                    margin: 0,
+                  },
+                  '@media (max-width: 500px)': {
+                    margin: 20,
+                  },
                 },
               },
             },
             { dir, global: true },
           );
+
+          instance.purgeStyles(GLOBAL_STYLE_NAME);
+
+          expect(getFlushedStyles()).toMatchSnapshot();
         });
 
         it('handles @font-face', () => {
@@ -193,6 +200,16 @@ describe('JSSAesthetic', () => {
       });
 
       describe('style sheet', () => {
+        it('flushes and purges styles from the DOM', () => {
+          const styles = { test: { display: 'block' } };
+
+          renderAndExpect(instance, styles, styles, { dir });
+
+          instance.purgeStyles();
+
+          expect(getFlushedStyles()).toMatchSnapshot();
+        });
+
         it('converts unified syntax to native syntax and transforms to a class name', () => {
           renderAndExpect(
             instance,

--- a/packages/adapter-jss/tests/JSSAesthetic.test.ts
+++ b/packages/adapter-jss/tests/JSSAesthetic.test.ts
@@ -71,7 +71,7 @@ describe('JSSAesthetic', () => {
       });
 
       describe('global sheet', () => {
-        it('flushes and purges styles from the DOM', () => {
+        it('flushes and purges global styles from the DOM', () => {
           renderAndExpect(
             instance,
             SYNTAX_GLOBAL,
@@ -200,7 +200,7 @@ describe('JSSAesthetic', () => {
       });
 
       describe('style sheet', () => {
-        it('flushes and purges styles from the DOM', () => {
+        it('flushes and purges all styles from the DOM', () => {
           const styles = { test: { display: 'block' } };
 
           renderAndExpect(instance, styles, styles, { dir });

--- a/packages/adapter-jss/tests/__snapshots__/JSSAesthetic.test.ts.snap
+++ b/packages/adapter-jss/tests/__snapshots__/JSSAesthetic.test.ts.snap
@@ -10,7 +10,7 @@ exports[`JSSAesthetic LTR converts and transforms inline styles 2`] = `
 .inline-1-0-1-2 {padding: 2px;}"
 `;
 
-exports[`JSSAesthetic LTR global sheet flushes and purges styles from the DOM 1`] = `
+exports[`JSSAesthetic LTR global sheet flushes and purges global styles from the DOM 1`] = `
 "body {margin: 0;}
 html {height: 100%;}
 a {color: red;}
@@ -21,9 +21,9 @@ ul> li {margin: 0;}
 @media (max-width: 500px) {ul {margin: 20px;}}"
 `;
 
-exports[`JSSAesthetic LTR global sheet flushes and purges styles from the DOM 2`] = `""`;
+exports[`JSSAesthetic LTR global sheet flushes and purges global styles from the DOM 2`] = `""`;
 
-exports[`JSSAesthetic LTR global sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`JSSAesthetic LTR global sheet flushes and purges global styles from the DOM 3`] = `""`;
 
 exports[`JSSAesthetic LTR global sheet handles @charset 1`] = `""`;
 
@@ -85,11 +85,11 @@ exports[`JSSAesthetic LTR style sheet converts unified syntax to native syntax a
 
 exports[`JSSAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button-0-12-1"`;
 
-exports[`JSSAesthetic LTR style sheet flushes and purges styles from the DOM 1`] = `".test-0-11-1 {display: block;}"`;
+exports[`JSSAesthetic LTR style sheet flushes and purges all styles from the DOM 1`] = `".test-0-11-1 {display: block;}"`;
 
-exports[`JSSAesthetic LTR style sheet flushes and purges styles from the DOM 2`] = `"test-0-11-1"`;
+exports[`JSSAesthetic LTR style sheet flushes and purges all styles from the DOM 2`] = `"test-0-11-1"`;
 
-exports[`JSSAesthetic LTR style sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`JSSAesthetic LTR style sheet flushes and purges all styles from the DOM 3`] = `""`;
 
 exports[`JSSAesthetic LTR style sheet handles @fallbacks 1`] = `".fallback-0-20-1 {background: linear-gradient(...); display: flex; color: blue;}"`;
 
@@ -202,7 +202,7 @@ exports[`JSSAesthetic RTL converts and transforms inline styles 2`] = `
 .inline-1-0-25-2 {padding: 2px;}"
 `;
 
-exports[`JSSAesthetic RTL global sheet flushes and purges styles from the DOM 1`] = `
+exports[`JSSAesthetic RTL global sheet flushes and purges global styles from the DOM 1`] = `
 "body {margin: 0;}
 html {height: 100%;}
 a {color: red;}
@@ -213,9 +213,9 @@ ul> li {margin: 0;}
 @media (max-width: 500px) {ul {margin: 20px;}}"
 `;
 
-exports[`JSSAesthetic RTL global sheet flushes and purges styles from the DOM 2`] = `""`;
+exports[`JSSAesthetic RTL global sheet flushes and purges global styles from the DOM 2`] = `""`;
 
-exports[`JSSAesthetic RTL global sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`JSSAesthetic RTL global sheet flushes and purges global styles from the DOM 3`] = `""`;
 
 exports[`JSSAesthetic RTL global sheet handles @charset 1`] = `""`;
 
@@ -277,11 +277,11 @@ exports[`JSSAesthetic RTL style sheet converts unified syntax to native syntax a
 
 exports[`JSSAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button-0-36-1"`;
 
-exports[`JSSAesthetic RTL style sheet flushes and purges styles from the DOM 1`] = `".test-0-35-1 {display: block;}"`;
+exports[`JSSAesthetic RTL style sheet flushes and purges all styles from the DOM 1`] = `".test-0-35-1 {display: block;}"`;
 
-exports[`JSSAesthetic RTL style sheet flushes and purges styles from the DOM 2`] = `"test-0-35-1"`;
+exports[`JSSAesthetic RTL style sheet flushes and purges all styles from the DOM 2`] = `"test-0-35-1"`;
 
-exports[`JSSAesthetic RTL style sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`JSSAesthetic RTL style sheet flushes and purges all styles from the DOM 3`] = `""`;
 
 exports[`JSSAesthetic RTL style sheet handles @fallbacks 1`] = `".fallback-0-44-1 {background: linear-gradient(...); display: flex; color: blue;}"`;
 

--- a/packages/adapter-jss/tests/__snapshots__/JSSAesthetic.test.ts.snap
+++ b/packages/adapter-jss/tests/__snapshots__/JSSAesthetic.test.ts.snap
@@ -10,11 +10,20 @@ exports[`JSSAesthetic LTR converts and transforms inline styles 2`] = `
 .inline-1-0-1-2 {padding: 2px;}"
 `;
 
-exports[`JSSAesthetic LTR flushes and purges styles from the DOM 1`] = `".test-0-2-1 {display: block;}"`;
+exports[`JSSAesthetic LTR global sheet flushes and purges styles from the DOM 1`] = `
+"body {margin: 0;}
+html {height: 100%;}
+a {color: red;}
+a:hover {color: darkred;}
+a:focus {color: lightred;}
+ul {margin: 0;}
+ul> li {margin: 0;}
+@media (max-width: 500px) {ul {margin: 20px;}}"
+`;
 
-exports[`JSSAesthetic LTR flushes and purges styles from the DOM 2`] = `"test-0-2-1"`;
+exports[`JSSAesthetic LTR global sheet flushes and purges styles from the DOM 2`] = `""`;
 
-exports[`JSSAesthetic LTR flushes and purges styles from the DOM 3`] = `""`;
+exports[`JSSAesthetic LTR global sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`JSSAesthetic LTR global sheet handles @charset 1`] = `""`;
 
@@ -36,15 +45,6 @@ exports[`JSSAesthetic LTR global sheet handles @keyframes 2`] = `""`;
 exports[`JSSAesthetic LTR global sheet handles @viewport 1`] = `"@viewport {width: device-width; orientation: landscape;}"`;
 
 exports[`JSSAesthetic LTR global sheet handles @viewport 2`] = `""`;
-
-exports[`JSSAesthetic LTR global sheet handles globals 1`] = `
-"body {margin: 0;}
-html {height: 100%;}
-a {color: red;}
-a:hover {color: darkred;}"
-`;
-
-exports[`JSSAesthetic LTR global sheet handles globals 2`] = `""`;
 
 exports[`JSSAesthetic LTR global sheet handles mixed @font-face 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; src: local('Robo'), url('fonts/Roboto.woff2') format('woff2'), url('fonts/Roboto.ttf') format('truetype');}
@@ -84,6 +84,12 @@ exports[`JSSAesthetic LTR style sheet converts unified syntax to native syntax a
 `;
 
 exports[`JSSAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button-0-12-1"`;
+
+exports[`JSSAesthetic LTR style sheet flushes and purges styles from the DOM 1`] = `".test-0-11-1 {display: block;}"`;
+
+exports[`JSSAesthetic LTR style sheet flushes and purges styles from the DOM 2`] = `"test-0-11-1"`;
+
+exports[`JSSAesthetic LTR style sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`JSSAesthetic LTR style sheet handles @fallbacks 1`] = `".fallback-0-20-1 {background: linear-gradient(...); display: flex; color: blue;}"`;
 
@@ -196,11 +202,20 @@ exports[`JSSAesthetic RTL converts and transforms inline styles 2`] = `
 .inline-1-0-25-2 {padding: 2px;}"
 `;
 
-exports[`JSSAesthetic RTL flushes and purges styles from the DOM 1`] = `".test-0-26-1 {display: block;}"`;
+exports[`JSSAesthetic RTL global sheet flushes and purges styles from the DOM 1`] = `
+"body {margin: 0;}
+html {height: 100%;}
+a {color: red;}
+a:hover {color: darkred;}
+a:focus {color: lightred;}
+ul {margin: 0;}
+ul> li {margin: 0;}
+@media (max-width: 500px) {ul {margin: 20px;}}"
+`;
 
-exports[`JSSAesthetic RTL flushes and purges styles from the DOM 2`] = `"test-0-26-1"`;
+exports[`JSSAesthetic RTL global sheet flushes and purges styles from the DOM 2`] = `""`;
 
-exports[`JSSAesthetic RTL flushes and purges styles from the DOM 3`] = `""`;
+exports[`JSSAesthetic RTL global sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`JSSAesthetic RTL global sheet handles @charset 1`] = `""`;
 
@@ -222,15 +237,6 @@ exports[`JSSAesthetic RTL global sheet handles @keyframes 2`] = `""`;
 exports[`JSSAesthetic RTL global sheet handles @viewport 1`] = `"@viewport {width: device-width; orientation: landscape;}"`;
 
 exports[`JSSAesthetic RTL global sheet handles @viewport 2`] = `""`;
-
-exports[`JSSAesthetic RTL global sheet handles globals 1`] = `
-"body {margin: 0;}
-html {height: 100%;}
-a {color: red;}
-a:hover {color: darkred;}"
-`;
-
-exports[`JSSAesthetic RTL global sheet handles globals 2`] = `""`;
 
 exports[`JSSAesthetic RTL global sheet handles mixed @font-face 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; src: local('Robo'), url('fonts/Roboto.woff2') format('woff2'), url('fonts/Roboto.ttf') format('truetype');}
@@ -270,6 +276,12 @@ exports[`JSSAesthetic RTL style sheet converts unified syntax to native syntax a
 `;
 
 exports[`JSSAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button-0-36-1"`;
+
+exports[`JSSAesthetic RTL style sheet flushes and purges styles from the DOM 1`] = `".test-0-35-1 {display: block;}"`;
+
+exports[`JSSAesthetic RTL style sheet flushes and purges styles from the DOM 2`] = `"test-0-35-1"`;
+
+exports[`JSSAesthetic RTL style sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`JSSAesthetic RTL style sheet handles @fallbacks 1`] = `".fallback-0-44-1 {background: linear-gradient(...); display: flex; color: blue;}"`;
 

--- a/packages/adapter-typestyle/src/TypeStyleAesthetic.ts
+++ b/packages/adapter-typestyle/src/TypeStyleAesthetic.ts
@@ -1,6 +1,14 @@
 /* eslint-disable no-underscore-dangle */
 
-import Aesthetic, { AestheticOptions, ClassName, Ruleset, Sheet, SheetMap } from 'aesthetic';
+import Aesthetic, {
+  AestheticOptions,
+  ClassName,
+  Ruleset,
+  Sheet,
+  SheetMap,
+  StyleName,
+  GLOBAL_STYLE_NAME,
+} from 'aesthetic';
 import { purgeStyles } from 'aesthetic-utils';
 import { TypeStyle } from 'typestyle';
 import { NativeBlock, ParsedBlock } from './types';
@@ -45,12 +53,12 @@ export default class TypeStyleAesthetic<Theme extends object> extends Aesthetic<
     return this.typeStyle.stylesheet(styleSheet);
   }
 
-  purgeStyles() {
+  purgeStyles(styleName?: StyleName) {
     // @ts-ignore
     const element: HTMLStyleElement | undefined = this.typeStyle._tag;
 
     if (element) {
-      purgeStyles(element);
+      purgeStyles(element, styleName === GLOBAL_STYLE_NAME);
     }
   }
 

--- a/packages/adapter-typestyle/tests/TypeStyleAesthetic.test.ts
+++ b/packages/adapter-typestyle/tests/TypeStyleAesthetic.test.ts
@@ -53,7 +53,7 @@ describe('TypeStyleAesthetic', () => {
       });
 
       describe('global sheet', () => {
-        it('flushes and purges styles from the DOM', () => {
+        it('flushes and purges global styles from the DOM', () => {
           renderAndExpect(instance, SYNTAX_GLOBAL, {}, { dir, global: true });
 
           instance.purgeStyles(GLOBAL_STYLE_NAME);
@@ -99,7 +99,7 @@ describe('TypeStyleAesthetic', () => {
       });
 
       describe('style sheet', () => {
-        it('flushes and purges styles from the DOM', () => {
+        it('flushes and purges all styles from the DOM', () => {
           renderAndExpect(
             instance,
             { test: { display: 'block' } },

--- a/packages/adapter-typestyle/tests/TypeStyleAesthetic.test.ts
+++ b/packages/adapter-typestyle/tests/TypeStyleAesthetic.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jest/expect-expect */
 
 import { TypeStyle } from 'typestyle';
+import { GLOBAL_STYLE_NAME } from 'aesthetic';
 import {
   cleanupStyleElements,
   getFlushedStyles,
@@ -51,22 +52,13 @@ describe('TypeStyleAesthetic', () => {
         );
       });
 
-      it('flushes and purges styles from the DOM', () => {
-        renderAndExpect(
-          instance,
-          { test: { display: 'block' } },
-          { test: { $debugName: 'test', display: 'block' } },
-          { dir },
-        );
-
-        instance.purgeStyles();
-
-        expect(getFlushedStyles()).toMatchSnapshot();
-      });
-
       describe('global sheet', () => {
-        it('handles globals', () => {
+        it('flushes and purges styles from the DOM', () => {
           renderAndExpect(instance, SYNTAX_GLOBAL, {}, { dir, global: true });
+
+          instance.purgeStyles(GLOBAL_STYLE_NAME);
+
+          expect(getFlushedStyles()).toMatchSnapshot();
         });
 
         it('handles @font-face', () => {
@@ -107,6 +99,19 @@ describe('TypeStyleAesthetic', () => {
       });
 
       describe('style sheet', () => {
+        it('flushes and purges styles from the DOM', () => {
+          renderAndExpect(
+            instance,
+            { test: { display: 'block' } },
+            { test: { $debugName: 'test', display: 'block' } },
+            { dir },
+          );
+
+          instance.purgeStyles();
+
+          expect(getFlushedStyles()).toMatchSnapshot();
+        });
+
         it('converts unified syntax to native syntax and transforms to a class name', () => {
           instance.typeStyle.fontFace(FONT_ROBOTO as any);
 

--- a/packages/adapter-typestyle/tests/__snapshots__/TypeStyleAesthetic.test.ts.snap
+++ b/packages/adapter-typestyle/tests/__snapshots__/TypeStyleAesthetic.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TypeStyleAesthetic LTR global sheet flushes and purges styles from the DOM 1`] = `
+exports[`TypeStyleAesthetic LTR global sheet flushes and purges global styles from the DOM 1`] = `
 "html {height: 100%;}
 a {color: red;}
 a:hover {color: darkred;}
@@ -9,9 +9,9 @@ body,ul,ul> li {margin: 0;}
 @media (max-width: 500px) {ul {margin: 20px;}}"
 `;
 
-exports[`TypeStyleAesthetic LTR global sheet flushes and purges styles from the DOM 2`] = `""`;
+exports[`TypeStyleAesthetic LTR global sheet flushes and purges global styles from the DOM 2`] = `""`;
 
-exports[`TypeStyleAesthetic LTR global sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`TypeStyleAesthetic LTR global sheet flushes and purges global styles from the DOM 3`] = `""`;
 
 exports[`TypeStyleAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; local: Robo; src-paths: fonts/Roboto.ttf;}
@@ -27,11 +27,11 @@ exports[`TypeStyleAesthetic LTR style sheet converts unified syntax to native sy
 
 exports[`TypeStyleAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button_f1sm9ltv"`;
 
-exports[`TypeStyleAesthetic LTR style sheet flushes and purges styles from the DOM 1`] = `".test_fcmecz0 {display: block;}"`;
+exports[`TypeStyleAesthetic LTR style sheet flushes and purges all styles from the DOM 1`] = `".test_fcmecz0 {display: block;}"`;
 
-exports[`TypeStyleAesthetic LTR style sheet flushes and purges styles from the DOM 2`] = `"test_fcmecz0"`;
+exports[`TypeStyleAesthetic LTR style sheet flushes and purges all styles from the DOM 2`] = `"test_fcmecz0"`;
 
-exports[`TypeStyleAesthetic LTR style sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`TypeStyleAesthetic LTR style sheet flushes and purges all styles from the DOM 3`] = `""`;
 
 exports[`TypeStyleAesthetic LTR style sheet handles @fallbacks 1`] = `".fallback_f35p7vi {background: linear-gradient(...); color: blue; display: flex;}"`;
 
@@ -131,7 +131,7 @@ exports[`TypeStyleAesthetic LTR style sheet handles raw CSS 1`] = `
 
 exports[`TypeStyleAesthetic LTR style sheet handles raw CSS 2`] = `""`;
 
-exports[`TypeStyleAesthetic RTL global sheet flushes and purges styles from the DOM 1`] = `
+exports[`TypeStyleAesthetic RTL global sheet flushes and purges global styles from the DOM 1`] = `
 "html {height: 100%;}
 a {color: red;}
 a:hover {color: darkred;}
@@ -140,9 +140,9 @@ body,ul,ul> li {margin: 0;}
 @media (max-width: 500px) {ul {margin: 20px;}}"
 `;
 
-exports[`TypeStyleAesthetic RTL global sheet flushes and purges styles from the DOM 2`] = `""`;
+exports[`TypeStyleAesthetic RTL global sheet flushes and purges global styles from the DOM 2`] = `""`;
 
-exports[`TypeStyleAesthetic RTL global sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`TypeStyleAesthetic RTL global sheet flushes and purges global styles from the DOM 3`] = `""`;
 
 exports[`TypeStyleAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; local: Robo; src-paths: fonts/Roboto.ttf;}
@@ -158,11 +158,11 @@ exports[`TypeStyleAesthetic RTL style sheet converts unified syntax to native sy
 
 exports[`TypeStyleAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button_fjoi737"`;
 
-exports[`TypeStyleAesthetic RTL style sheet flushes and purges styles from the DOM 1`] = `".test_fcmecz0 {display: block;}"`;
+exports[`TypeStyleAesthetic RTL style sheet flushes and purges all styles from the DOM 1`] = `".test_fcmecz0 {display: block;}"`;
 
-exports[`TypeStyleAesthetic RTL style sheet flushes and purges styles from the DOM 2`] = `"test_fcmecz0"`;
+exports[`TypeStyleAesthetic RTL style sheet flushes and purges all styles from the DOM 2`] = `"test_fcmecz0"`;
 
-exports[`TypeStyleAesthetic RTL style sheet flushes and purges styles from the DOM 3`] = `""`;
+exports[`TypeStyleAesthetic RTL style sheet flushes and purges all styles from the DOM 3`] = `""`;
 
 exports[`TypeStyleAesthetic RTL style sheet handles @fallbacks 1`] = `".fallback_f35p7vi {background: linear-gradient(...); color: blue; display: flex;}"`;
 

--- a/packages/adapter-typestyle/tests/__snapshots__/TypeStyleAesthetic.test.ts.snap
+++ b/packages/adapter-typestyle/tests/__snapshots__/TypeStyleAesthetic.test.ts.snap
@@ -1,19 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TypeStyleAesthetic LTR flushes and purges styles from the DOM 1`] = `".test_fcmecz0 {display: block;}"`;
-
-exports[`TypeStyleAesthetic LTR flushes and purges styles from the DOM 2`] = `"test_fcmecz0"`;
-
-exports[`TypeStyleAesthetic LTR flushes and purges styles from the DOM 3`] = `""`;
-
-exports[`TypeStyleAesthetic LTR global sheet handles globals 1`] = `
-"body {margin: 0;}
-html {height: 100%;}
+exports[`TypeStyleAesthetic LTR global sheet flushes and purges styles from the DOM 1`] = `
+"html {height: 100%;}
 a {color: red;}
-a:hover {color: darkred;}"
+a:hover {color: darkred;}
+a:focus {color: lightred;}
+body,ul,ul> li {margin: 0;}
+@media (max-width: 500px) {ul {margin: 20px;}}"
 `;
 
-exports[`TypeStyleAesthetic LTR global sheet handles globals 2`] = `""`;
+exports[`TypeStyleAesthetic LTR global sheet flushes and purges styles from the DOM 2`] = `""`;
+
+exports[`TypeStyleAesthetic LTR global sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`TypeStyleAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; local: Robo; src-paths: fonts/Roboto.ttf;}
@@ -28,6 +26,12 @@ exports[`TypeStyleAesthetic LTR style sheet converts unified syntax to native sy
 `;
 
 exports[`TypeStyleAesthetic LTR style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button_f1sm9ltv"`;
+
+exports[`TypeStyleAesthetic LTR style sheet flushes and purges styles from the DOM 1`] = `".test_fcmecz0 {display: block;}"`;
+
+exports[`TypeStyleAesthetic LTR style sheet flushes and purges styles from the DOM 2`] = `"test_fcmecz0"`;
+
+exports[`TypeStyleAesthetic LTR style sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`TypeStyleAesthetic LTR style sheet handles @fallbacks 1`] = `".fallback_f35p7vi {background: linear-gradient(...); color: blue; display: flex;}"`;
 
@@ -127,20 +131,18 @@ exports[`TypeStyleAesthetic LTR style sheet handles raw CSS 1`] = `
 
 exports[`TypeStyleAesthetic LTR style sheet handles raw CSS 2`] = `""`;
 
-exports[`TypeStyleAesthetic RTL flushes and purges styles from the DOM 1`] = `".test_fcmecz0 {display: block;}"`;
-
-exports[`TypeStyleAesthetic RTL flushes and purges styles from the DOM 2`] = `"test_fcmecz0"`;
-
-exports[`TypeStyleAesthetic RTL flushes and purges styles from the DOM 3`] = `""`;
-
-exports[`TypeStyleAesthetic RTL global sheet handles globals 1`] = `
-"body {margin: 0;}
-html {height: 100%;}
+exports[`TypeStyleAesthetic RTL global sheet flushes and purges styles from the DOM 1`] = `
+"html {height: 100%;}
 a {color: red;}
-a:hover {color: darkred;}"
+a:hover {color: darkred;}
+a:focus {color: lightred;}
+body,ul,ul> li {margin: 0;}
+@media (max-width: 500px) {ul {margin: 20px;}}"
 `;
 
-exports[`TypeStyleAesthetic RTL global sheet handles globals 2`] = `""`;
+exports[`TypeStyleAesthetic RTL global sheet flushes and purges styles from the DOM 2`] = `""`;
+
+exports[`TypeStyleAesthetic RTL global sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`TypeStyleAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 1`] = `
 "@font-face {font-family: Roboto; font-style: normal; font-weight: normal; local: Robo; src-paths: fonts/Roboto.ttf;}
@@ -155,6 +157,12 @@ exports[`TypeStyleAesthetic RTL style sheet converts unified syntax to native sy
 `;
 
 exports[`TypeStyleAesthetic RTL style sheet converts unified syntax to native syntax and transforms to a class name 2`] = `"button_fjoi737"`;
+
+exports[`TypeStyleAesthetic RTL style sheet flushes and purges styles from the DOM 1`] = `".test_fcmecz0 {display: block;}"`;
+
+exports[`TypeStyleAesthetic RTL style sheet flushes and purges styles from the DOM 2`] = `"test_fcmecz0"`;
+
+exports[`TypeStyleAesthetic RTL style sheet flushes and purges styles from the DOM 3`] = `""`;
 
 exports[`TypeStyleAesthetic RTL style sheet handles @fallbacks 1`] = `".fallback_f35p7vi {background: linear-gradient(...); color: blue; display: flex;}"`;
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -29,7 +29,6 @@ slightly change.
   refresh the page (integration dependent).
 - Added `Aesthetic#isParsedBlock` for determining whether a style block is native or parsed.
 - Added `Aesthetic#purgeStyles`, so that adapters can clear their style sheets.
-- Added `getFlushedStyles`, `getStyleElements`, and `purgeStyles` helper functions.
 - Added an options object to `Aesthetic#createStyleSheet`, `Aeshetic#transformStyles`,
   `UnifiedSyntax#convertGlobalSheet`, `UnifiedSyntax#convertStyleSheet`, and `Sheet`.
 - Updated `Aeshetic#transformStyles` to convert native blocks to parsed blocks before transforming

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "aesthetic-utils": "^2.0.0-alpha.6",
-    "css-in-js-utils": "^3.0.2",
     "csstype": "^2.6.5",
     "extend": "^3.0.2",
     "rtl-css-js": "^1.13.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "aesthetic-utils": "^2.0.0-alpha.6",
+    "css-in-js-utils": "^3.0.2",
     "csstype": "^2.6.5",
     "extend": "^3.0.2",
     "rtl-css-js": "^1.13.0",

--- a/packages/core/src/Aesthetic.tsx
+++ b/packages/core/src/Aesthetic.tsx
@@ -96,8 +96,7 @@ export default abstract class Aesthetic<
 
   /**
    * Change the current theme to another registered theme.
-   * This requires all flushed styles to be purged, and for new styles
-   * to be regenerated.
+   * This will purge all flushed global styles and regenerate new ones.
    */
   changeTheme(themeName: ThemeName): this {
     const oldTheme = this.options.theme;
@@ -108,7 +107,7 @@ export default abstract class Aesthetic<
 
     // Purge previous global styles
     this.purgeStyles(GLOBAL_STYLE_NAME);
-    this.cacheManager.clear(unit => Boolean(unit.global && unit.theme === oldTheme));
+    this.cacheManager.clear(unit => !!unit.global && unit.theme === oldTheme);
 
     // Generate new global styles
     this.applyGlobalStyles({ theme: themeName });
@@ -180,15 +179,16 @@ export default abstract class Aesthetic<
   }
 
   /**
-   * Flush transformed styles and inject them into the DOM.
+   * Flush a target component's transformed styles and inject them into the DOM.
+   * If no target defined, will flush all buffered styles.
    */
-  flushStyles(styleName: StyleName) {}
+  flushStyles(styleName?: StyleName) {}
 
   /**
-   * Retrieve the defined component style sheet for the current theme.
+   * Retrieve the component style sheet for the defined theme.
    * If the definition is a function, execute it while passing the current theme.
    */
-  getStyleSheet(styleName: StyleName, themeName?: ThemeName): StyleSheet {
+  getStyleSheet(styleName: StyleName, themeName: ThemeName): StyleSheet {
     const parentStyleName = this.parents[styleName];
     const styleDef = this.styles[styleName];
     const styleSheet = styleDef(this.getTheme(themeName || this.options.theme));
@@ -233,8 +233,8 @@ export default abstract class Aesthetic<
   }
 
   /**
-   * Purge and remove all flushed styles from the DOM.
-   * If no name is provided, purge all transformed styles.
+   * Purge and remove all styles from the DOM for the target component.
+   * If no target defined, will purge all possible styles.
    */
   purgeStyles(styleName?: StyleName) {}
 

--- a/packages/core/src/Aesthetic.tsx
+++ b/packages/core/src/Aesthetic.tsx
@@ -5,6 +5,7 @@ import CacheManager from './CacheManager';
 import Sheet from './Sheet';
 import StyleSheetManager from './StyleSheetManager';
 import UnifiedSyntax from './UnifiedSyntax';
+import { GLOBAL_STYLE_NAME } from './constants';
 import {
   AestheticOptions,
   ClassName,
@@ -60,17 +61,16 @@ export default abstract class Aesthetic<
     // so set this programmatically based on the defined option.
     document.documentElement.setAttribute('dir', this.options.rtl ? 'rtl' : 'ltr');
 
-    const name = ':root';
     const options = this.getPreparedTransformOptions({
       ...baseOptions,
       global: true,
-      name,
+      name: GLOBAL_STYLE_NAME,
     });
 
     // Direction changes shouldn't regenerate global styles
     delete options.dir;
 
-    const cache = this.cacheManager.get(name, options);
+    const cache = this.cacheManager.get(GLOBAL_STYLE_NAME, options);
     const globalDef = this.globals[options.theme];
 
     if (cache || !globalDef) {
@@ -79,14 +79,17 @@ export default abstract class Aesthetic<
 
     const globalSheet = globalDef(this.getTheme(options.theme));
     const parsedSheet = this.cacheManager.set(
-      name,
-      this.parseStyleSheet(this.syntax.convertGlobalSheet(globalSheet, options).toObject(), name),
+      GLOBAL_STYLE_NAME,
+      this.parseStyleSheet(
+        this.syntax.convertGlobalSheet(globalSheet, options).toObject(),
+        GLOBAL_STYLE_NAME,
+      ),
       options,
     );
 
     // Some adapters require the styles to be transformed to be flushed
     this.transformStyles(Object.values(parsedSheet), options);
-    this.flushStyles(name);
+    this.flushStyles(GLOBAL_STYLE_NAME);
 
     return this;
   }
@@ -97,9 +100,15 @@ export default abstract class Aesthetic<
    * to be regenerated.
    */
   changeTheme(themeName: ThemeName): this {
+    const oldTheme = this.options.theme;
+
     // Set theme as new option
     this.getTheme(themeName);
     this.options.theme = themeName;
+
+    // Purge previous global styles
+    this.purgeStyles(GLOBAL_STYLE_NAME);
+    this.cacheManager.clear(unit => Boolean(unit.global && unit.theme === oldTheme));
 
     // Generate new global styles
     this.applyGlobalStyles({ theme: themeName });
@@ -227,7 +236,7 @@ export default abstract class Aesthetic<
    * Purge and remove all flushed styles from the DOM.
    * If no name is provided, purge all transformed styles.
    */
-  purgeStyles() {}
+  purgeStyles(styleName?: StyleName) {}
 
   /**
    * Register a style sheet definition. Optionally extend from a parent style sheet if defined.

--- a/packages/core/src/CacheManager.ts
+++ b/packages/core/src/CacheManager.ts
@@ -13,6 +13,18 @@ export interface CacheUnit<T> extends CacheTags {
 export default class CacheManager<T> {
   protected cache: Map<string, CacheUnit<T>[]> = new Map();
 
+  clear(filter?: (unit: CacheUnit<T>) => boolean): this {
+    if (filter) {
+      this.cache.forEach((units, key) => {
+        this.cache.set(key, units.filter(unit => !filter(unit)));
+      });
+    } else {
+      this.cache.clear();
+    }
+
+    return this;
+  }
+
   compare(unit: CacheUnit<T>, tags: CacheTags): boolean {
     return unit.dir === tags.dir && unit.global === tags.global && unit.theme === tags.theme;
   }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,0 +1,1 @@
+export const GLOBAL_STYLE_NAME = ':root';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ import UnifiedSyntax from './UnifiedSyntax';
 import Ruleset from './Ruleset';
 import Sheet from './Sheet';
 
+export * from './constants';
 export * from './types';
 
 export { ClassNameAesthetic, UnifiedSyntax, Ruleset, Sheet };

--- a/packages/core/src/testUtils.ts
+++ b/packages/core/src/testUtils.ts
@@ -334,6 +334,24 @@ export const SYNTAX_GLOBAL = {
       ':hover': {
         color: 'darkred',
       },
+      '@selectors': {
+        ':focus': {
+          color: 'lightred',
+        },
+      },
+    },
+    ul: {
+      margin: 0,
+      '@selectors': {
+        '> li': {
+          margin: 0,
+        },
+      },
+      '@media': {
+        '(max-width: 500px)': {
+          margin: 20,
+        },
+      },
     },
   },
 };

--- a/packages/core/src/testUtils.ts
+++ b/packages/core/src/testUtils.ts
@@ -9,6 +9,7 @@ import {
 } from 'aesthetic-utils';
 import Aesthetic from './Aesthetic';
 import { FontFace, Direction } from './types';
+import { GLOBAL_STYLE_NAME } from './constants';
 
 export { getStyleElements };
 
@@ -91,7 +92,9 @@ export function renderAndExpect(
     global?: boolean;
   },
 ) {
-  const name = aesthetic.constructor.name.replace('Aesthetic', '').toLowerCase();
+  const name = global
+    ? GLOBAL_STYLE_NAME
+    : aesthetic.constructor.name.replace('Aesthetic', '').toLowerCase();
   const options = { name, dir };
   const convertedSheet = global
     ? aesthetic.syntax.convertGlobalSheet(styleSheet, options).toObject()

--- a/packages/core/tests/Aesthetic.test.tsx
+++ b/packages/core/tests/Aesthetic.test.tsx
@@ -113,8 +113,25 @@ describe('Aesthetic', () => {
       expect(instance.options.theme).toBe('light');
     });
 
-    it('resets and applies global styles', () => {
+    it('purges old global styles', () => {
+      const spy = jest.spyOn(instance, 'purgeStyles');
+
+      instance.changeTheme('light');
+
+      expect(spy).toHaveBeenCalledWith(GLOBAL_STYLE_NAME);
+    });
+
+    it('applies new global styles', () => {
       const spy = jest.spyOn(instance, 'applyGlobalStyles');
+
+      instance.changeTheme('light');
+
+      expect(spy).toHaveBeenCalledWith({ theme: 'light' });
+    });
+
+    it('clears cache', () => {
+      // @ts-ignore Allow access
+      const spy = jest.spyOn(instance.cacheManager, 'clear');
 
       instance.changeTheme('light');
 
@@ -288,15 +305,13 @@ describe('Aesthetic', () => {
     });
 
     it('errors if no theme', () => {
-      instance.options.theme = 'unknown';
-
       expect(() => {
-        instance.getStyleSheet('foo');
+        instance.getStyleSheet('foo', 'unknown');
       }).toThrowErrorMatchingSnapshot();
     });
 
     it('returns the style sheet', () => {
-      expect(instance.getStyleSheet('foo')).toEqual({
+      expect(instance.getStyleSheet('foo', 'default')).toEqual({
         el: { display: 'block' },
       });
     });
@@ -306,7 +321,7 @@ describe('Aesthetic', () => {
         el: { padding: theme.unit * 2 },
       }));
 
-      expect(instance.getStyleSheet('bar')).toEqual({
+      expect(instance.getStyleSheet('bar', 'default')).toEqual({
         el: { padding: 16 },
       });
     });
@@ -342,7 +357,7 @@ describe('Aesthetic', () => {
         'baz',
       );
 
-      expect(instance.getStyleSheet('bar')).toEqual({
+      expect(instance.getStyleSheet('bar', 'default')).toEqual({
         el: {
           color: 'red',
           ':hover': {
@@ -351,7 +366,7 @@ describe('Aesthetic', () => {
         },
       });
 
-      expect(instance.getStyleSheet('baz')).toEqual({
+      expect(instance.getStyleSheet('baz', 'default')).toEqual({
         el: {
           color: 'red',
           background: 'blue',
@@ -361,7 +376,7 @@ describe('Aesthetic', () => {
         },
       });
 
-      expect(instance.getStyleSheet('qux')).toEqual({
+      expect(instance.getStyleSheet('qux', 'default')).toEqual({
         el: {
           color: 'red',
           background: 'blue',

--- a/packages/core/tests/Aesthetic.test.tsx
+++ b/packages/core/tests/Aesthetic.test.tsx
@@ -1,5 +1,6 @@
 import Aesthetic from '../src/Aesthetic';
 import StyleSheetManager from '../src/StyleSheetManager';
+import { GLOBAL_STYLE_NAME } from '../src/constants';
 import { TestTheme, registerTestTheme, SYNTAX_GLOBAL } from '../src/testUtils';
 
 describe('Aesthetic', () => {
@@ -71,7 +72,7 @@ describe('Aesthetic', () => {
 
       instance.applyGlobalStyles({});
 
-      expect(spy).toHaveBeenCalledWith({}, ':root');
+      expect(spy).toHaveBeenCalledWith({}, GLOBAL_STYLE_NAME);
     });
 
     it('sets `ltr` on document', () => {

--- a/packages/core/tests/CacheManager.test.ts
+++ b/packages/core/tests/CacheManager.test.ts
@@ -48,7 +48,7 @@ describe('CacheManager', () => {
     // @ts-ignore Allow access
     const cache = manager.cache.get('foo')!;
 
-    expect(cache.length).toBe(1);
+    expect(cache).toHaveLength(1);
     expect(cache[0]).toEqual({ dir: 'ltr', theme: 'dark', value: { value: 2 } });
   });
 });

--- a/packages/core/tests/CacheManager.test.ts
+++ b/packages/core/tests/CacheManager.test.ts
@@ -22,4 +22,33 @@ describe('CacheManager', () => {
     expect(manager.get('foo', { theme: 'dark' })).toBeNull();
     expect(manager.get('foo', { theme: 'dark', dir: 'rtl' })).toEqual({ value: 6 });
   });
+
+  it('clears all caches if no filter provided', () => {
+    manager.set('foo', { value: 1 }, { dir: 'ltr' });
+    manager.set('foo', { value: 2 }, { dir: 'ltr' });
+    manager.set('foo', { value: 3 }, { dir: 'ltr' });
+    manager.set('bar', { value: 1 }, { theme: 'light' });
+
+    // @ts-ignore Allow access
+    expect(manager.cache.size).toBe(2);
+
+    manager.clear();
+
+    // @ts-ignore Allow access
+    expect(manager.cache.size).toBe(0);
+  });
+
+  it('clears cache with the defined filter', () => {
+    manager.set('foo', { value: 1 }, { dir: 'ltr', theme: 'light' });
+    manager.set('foo', { value: 2 }, { dir: 'ltr', theme: 'dark' });
+    manager.set('foo', { value: 3 }, { dir: 'ltr', theme: 'light' });
+
+    manager.clear(unit => unit.theme === 'light');
+
+    // @ts-ignore Allow access
+    const cache = manager.cache.get('foo')!;
+
+    expect(cache.length).toBe(1);
+    expect(cache[0]).toEqual({ dir: 'ltr', theme: 'dark', value: { value: 2 } });
+  });
 });

--- a/packages/react/src/ThemeProvider.tsx
+++ b/packages/react/src/ThemeProvider.tsx
@@ -11,9 +11,13 @@ export default class ThemeProvider extends React.PureComponent<
   };
 
   componentDidUpdate(prevProps: ThemeProviderProps) {
-    const { name } = this.props;
+    const { aesthetic, name, propagate } = this.props;
 
     if (name && name !== prevProps.name) {
+      if (propagate) {
+        aesthetic.changeTheme(name);
+      }
+
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         themeName: name,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -21,6 +21,7 @@ export interface ThemeProviderProps {
   aesthetic: Aesthetic<any, any, any>;
   children: NonNullable<React.ReactNode>;
   name?: ThemeName;
+  propagate?: boolean;
 }
 
 export interface ThemeProviderState {

--- a/packages/react/tests/ThemeProvider.test.tsx
+++ b/packages/react/tests/ThemeProvider.test.tsx
@@ -66,4 +66,38 @@ describe('ThemeProvider', () => {
 
     expect(wrapper.state('themeName')).toBe('dark');
   });
+
+  it('calls `changeTheme` when `propagate` is true', () => {
+    const spy = jest.spyOn(aesthetic, 'changeTheme');
+    const wrapper = shallow<ThemeProvider>(
+      <ThemeProvider aesthetic={aesthetic} propagate>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </ThemeProvider>,
+    );
+
+    wrapper.setProps({
+      name: 'dark',
+    });
+
+    expect(spy).toHaveBeenCalledWith('dark');
+  });
+
+  it('doesnt call `changeTheme` when `propagate` is false', () => {
+    const spy = jest.spyOn(aesthetic, 'changeTheme');
+    const wrapper = shallow<ThemeProvider>(
+      <ThemeProvider aesthetic={aesthetic} propagate>
+        <div>1</div>
+        <div>2</div>
+        <div>3</div>
+      </ThemeProvider>,
+    );
+
+    wrapper.setProps({
+      name: 'dark',
+    });
+
+    expect(spy).toHaveBeenCalledWith('dark');
+  });
 });

--- a/packages/react/tests/withStylesFactory.test.tsx
+++ b/packages/react/tests/withStylesFactory.test.tsx
@@ -110,7 +110,7 @@ describe('withStylesFactory()', () => {
       },
     )(BaseComponent);
 
-    expect(aesthetic.getStyleSheet(Wrapped.styleName)).toEqual({
+    expect(aesthetic.getStyleSheet(Wrapped.styleName, 'default')).toEqual({
       button: {
         display: 'inline-block',
         padding: 5,
@@ -123,7 +123,7 @@ describe('withStylesFactory()', () => {
       },
     }));
 
-    expect(aesthetic.getStyleSheet(Extended.styleName)).toEqual({
+    expect(aesthetic.getStyleSheet(Extended.styleName, 'default')).toEqual({
       button: {
         display: 'inline-block',
         padding: 5,

--- a/packages/utils/src/purgeStyles.ts
+++ b/packages/utils/src/purgeStyles.ts
@@ -2,18 +2,89 @@
 
 import toArray from './toArray';
 
-export default function purgeStyles(styles: HTMLStyleElement | HTMLStyleElement[]) {
+type RulesContainer = CSSStyleSheet | CSSGroupingRule | CSSKeyframesRule;
+
+// Only matches global elements
+const NON_GLOBAL_PREFIX = /^(#|\.|@)/u;
+
+function containsNestedRules(rule: unknown): rule is RulesContainer {
+  return (
+    (typeof CSSStyleSheet !== 'undefined' && rule instanceof CSSStyleSheet) ||
+    (typeof CSSMediaRule !== 'undefined' && rule instanceof CSSMediaRule) ||
+    (typeof CSSSupportsRule !== 'undefined' && rule instanceof CSSSupportsRule) ||
+    (typeof CSSKeyframesRule !== 'undefined' && rule instanceof CSSKeyframesRule)
+  );
+}
+
+function deleteRule(parent: RulesContainer, ruleToDelete: CSSRule) {
+  Array.from(parent.cssRules).some((rule, index) => {
+    if (rule === ruleToDelete && parent.cssRules[index]) {
+      if (typeof parent.deleteRule === 'function') {
+        parent.deleteRule(index as any);
+      } else {
+        delete parent.cssRules[index];
+      }
+
+      return true;
+    }
+
+    return false;
+  });
+
+  // CSSOM doesn't implement deleteRule(), so we delete the rule by index above.
+  // Now we need to filter out the empty values or other features crash.
+  if (process.env.NODE_ENV === 'test') {
+    // @ts-ignore
+    parent.cssRules = parent.cssRules.filter(Boolean);
+  }
+
+  // Remove this rule from the parent if there are no more child rules
+  if (parent.cssRules.length === 0 && parent instanceof CSSRule) {
+    if (containsNestedRules(parent.parentRule)) {
+      deleteRule(parent.parentRule, parent);
+    } else if (containsNestedRules(parent.parentStyleSheet)) {
+      deleteRule(parent.parentStyleSheet, parent);
+    }
+  }
+}
+
+function purgeRules(parent: RulesContainer, onlyGlobals: boolean = false) {
+  if (!parent.cssRules) {
+    return;
+  }
+
+  const rulesToDelete: CSSRule[] = [];
+
+  // First pass to gather rules to delete. We can't delete rules within this
+  // loop as indices are reset each deletion, so subsequent deletions would be
+  // deleting the wrong indices. Sadly we have to do multiple passes and loops.
+  Array.from(parent.cssRules).forEach(rule => {
+    if (containsNestedRules(rule)) {
+      purgeRules(rule);
+    }
+
+    if (onlyGlobals && NON_GLOBAL_PREFIX.test(rule.cssText)) {
+      return;
+    }
+
+    rulesToDelete.push(rule);
+  });
+
+  // Second pass to actually delete the rules!
+  rulesToDelete.forEach(rule => {
+    deleteRule(parent, rule);
+  });
+}
+
+export default function purgeStyles(
+  styles: HTMLStyleElement | HTMLStyleElement[],
+  onlyGlobals: boolean = false,
+) {
   toArray(styles).forEach(style => {
     style.textContent = '';
 
-    const sheet = style.sheet as CSSStyleSheet;
-
-    if (sheet && sheet.cssRules) {
-      Array.from(sheet.cssRules).forEach((rule, index) => {
-        if (sheet.cssRules[index]) {
-          sheet.deleteRule(index);
-        }
-      });
+    if (containsNestedRules(style.sheet)) {
+      purgeRules(style.sheet, onlyGlobals);
     }
   });
 }

--- a/packages/utils/src/purgeStyles.ts
+++ b/packages/utils/src/purgeStyles.ts
@@ -2,7 +2,7 @@
 
 import toArray from './toArray';
 
-type RulesContainer = CSSStyleSheet | CSSGroupingRule | CSSKeyframesRule;
+type RulesContainer = CSSStyleSheet | CSSGroupingRule;
 
 // Only matches global elements
 const NON_GLOBAL_PREFIX = /^(#|\.|@)/u;
@@ -11,8 +11,7 @@ function containsNestedRules(rule: unknown): rule is RulesContainer {
   return (
     (typeof CSSStyleSheet !== 'undefined' && rule instanceof CSSStyleSheet) ||
     (typeof CSSMediaRule !== 'undefined' && rule instanceof CSSMediaRule) ||
-    (typeof CSSSupportsRule !== 'undefined' && rule instanceof CSSSupportsRule) ||
-    (typeof CSSKeyframesRule !== 'undefined' && rule instanceof CSSKeyframesRule)
+    (typeof CSSSupportsRule !== 'undefined' && rule instanceof CSSSupportsRule)
   );
 }
 
@@ -20,7 +19,7 @@ function deleteRule(parent: RulesContainer, ruleToDelete: CSSRule) {
   Array.from(parent.cssRules).some((rule, index) => {
     if (rule === ruleToDelete && parent.cssRules[index]) {
       if (typeof parent.deleteRule === 'function') {
-        parent.deleteRule(index as any);
+        parent.deleteRule(index);
       } else {
         delete parent.cssRules[index];
       }
@@ -42,7 +41,9 @@ function deleteRule(parent: RulesContainer, ruleToDelete: CSSRule) {
   if (parent.cssRules.length === 0 && parent instanceof CSSRule) {
     if (containsNestedRules(parent.parentRule)) {
       deleteRule(parent.parentRule, parent);
-    } else if (containsNestedRules(parent.parentStyleSheet)) {
+    }
+
+    if (containsNestedRules(parent.parentStyleSheet)) {
       deleteRule(parent.parentStyleSheet, parent);
     }
   }

--- a/tests/style.html
+++ b/tests/style.html
@@ -41,12 +41,19 @@
       );
 
       styles[0].sheet.insertRule(
+        `#test:hover {
+          background: lightgray;
+        }`,
+        2,
+      );
+
+      styles[0].sheet.insertRule(
         `@media (max-width: 900px) {
           #test {
             background: red;
           }
         }`,
-        2,
+        3,
       );
 
       styles.forEach(style => {

--- a/types/css-in-js-utils.d.ts
+++ b/types/css-in-js-utils.d.ts
@@ -1,0 +1,3 @@
+declare module 'css-in-js-utils' {
+  export function cssifyDeclaration(prop: string, value: unknown): string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4241,13 +4241,6 @@ css-in-js-utils@^3.0.0:
   dependencies:
     hyphenate-style-name "^1.0.2"
 
-css-in-js-utils@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.0.2.tgz#829a7922630458653a3f83c9b8dbd870c9eb2e24"
-  integrity sha512-D9VdAtwMADHMqQZPXYfsH2ARz+5JRf/Lv2R4euG+3bb9OxrM97QMJY68JwloLimbD8b/vsqOVZYHLPhyhaTcvw==
-  dependencies:
-    hyphenate-style-name "^1.0.2"
-
 css-modules-require-hook@^4.0.6:
   version "4.2.3"
   resolved "https://registry.npmjs.org/css-modules-require-hook/-/css-modules-require-hook-4.2.3.tgz#6792ca412b15e23e6f9be6a07dcef7f577ff904d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4241,6 +4241,13 @@ css-in-js-utils@^3.0.0:
   dependencies:
     hyphenate-style-name "^1.0.2"
 
+css-in-js-utils@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.0.2.tgz#829a7922630458653a3f83c9b8dbd870c9eb2e24"
+  integrity sha512-D9VdAtwMADHMqQZPXYfsH2ARz+5JRf/Lv2R4euG+3bb9OxrM97QMJY68JwloLimbD8b/vsqOVZYHLPhyhaTcvw==
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+
 css-modules-require-hook@^4.0.6:
   version "4.2.3"
   resolved "https://registry.npmjs.org/css-modules-require-hook/-/css-modules-require-hook-4.2.3.tgz#6792ca412b15e23e6f9be6a07dcef7f577ff904d"


### PR DESCRIPTION
Global styles via themes can still collide as there isn't a perfect solution. This PR adds a new layer to clear all previously flushed global styles so that switching themes actually works correctly.

It's still suggested to avoid adding globals that would collide.