### PR TITLE
Replace HOC classes with FCs + hooks

### DIFF
--- a/docs/integrations/react.md
+++ b/docs/integrations/react.md
@@ -57,8 +57,8 @@ export default withStylesFactory(aesthetic);
 ### withTheme
 
 The `withThemeFactory` function creates and returns a `withTheme` higher-order component. The HOC
-passes the current theme as a prop. It supports the `themePropName` and `pure`
-[options](../setup.md#options) mentioned previously as props.
+passes the current theme as a prop. It supports the `themePropName` [option](../setup.md#options)
+mentioned previously as props.
 
 ```ts
 // withTheme.ts
@@ -270,8 +270,7 @@ class ThemeSelector extends React.Component<{}, { value: string }> {
 ## Accessing The Theme
 
 There are 3 ways to access the currently enabled theme in a component. The first is with the aptly
-named `withTheme` HOC, which passes the theme object as a prop. The HOC supports the `pure` and
-`themePropName` options.
+named `withTheme` HOC, which passes the theme object as a prop.
 
 ```tsx
 import React from 'react';

--- a/docs/migrate/4.0.md
+++ b/docs/migrate/4.0.md
@@ -18,6 +18,21 @@ To better align our terminology, the following API methods have been renamed.
 - `Aesthetic#processStyleSheet` has been renamed to `parseStyleSheet`, to align with the adapter
   concept of parsing native blocks into parsed blocks.
 
+### Pure option has been removed
+
+The `pure` option passed to `Aesthetic` and `withStyles` has been removed in favor of functional
+components under the hood.
+
+```ts
+// Before
+new Aesthetic({ pure: true });
+withStyles({ pure: true })(Component);
+
+// After
+new Aesthetic();
+withStyles()(Component);
+```
+
 ### Styles can no longer be spread
 
 The `Aesthetic#transformStyles` method that generates CSS class names from parsed styles, has been

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,7 +8,6 @@ object as the 2nd argument. Please refer to each adapter for explicit usage.
 import AphroditeAesthetic from 'aesthetic-adapter-aphrodite';
 
 export default new AphroditeAesthetic(extensions, {
-  pure: true,
   theme: 'dark',
 });
 ```
@@ -23,8 +22,6 @@ The following options are available, most of which can be overridden per compone
   styles are locked and isolated. Defaults to `false`.
 - `passThemeProp` (boolean) - Should the theme prop be passed to all wrapped components? Defaults to
   `false`.
-- `pure` (boolean) - Should all HOC wrapped components use `React.PureComponent`? Defaults to
-  `true`. _(React only)_
 - `rtl` (boolean) - Enable right-to-left mode rendering for all components.
 - `stylesPropName` (string) - The name of the styles prop passed to wrapped components. Defaults to
   `styles`.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -11,7 +11,6 @@ slightly change.
   [aesthetic-react](https://github.com/milesj/aesthetic/tree/master/packages/react) package.
 - Helper functions have moved to the new
   [aesthetic-utils](https://github.com/milesj/aesthetic/tree/master/packages/utils) package.
-- Updated `Aesthetic#getTheme` to require a name argument. Will no longer default to active theme.
 - Updated `Aesthetic#transformStyles` to require all styles as an array in the 1st argument, instead
   of being spread across all arguments.
 - Updated `Aesthetic#transformToClassName` to only be passed the parsed blocks and not the native

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -18,6 +18,7 @@ slightly change.
   adapter blocks.
 - Renamed `Aesthetic#setStyleSheet` to `registerStyleSheet`.
 - Renamed `Aesthetic#processStyleSheet` to `parseStyleSheet`.
+- Removed the `pure` option (since class components are no longer used).
 
 #### 🚀 Updates
 

--- a/packages/core/src/Aesthetic.tsx
+++ b/packages/core/src/Aesthetic.tsx
@@ -246,7 +246,7 @@ export default abstract class Aesthetic<
       this.parents[styleName] = extendFrom;
     }
 
-    this.styles[styleName] = this.validateDefinition(styleName, styleSheet, this.styles);
+    this.styles[styleName] = this.validateDefinition(styleName, styleSheet);
 
     return this;
   }
@@ -269,7 +269,7 @@ export default abstract class Aesthetic<
     }
 
     this.themes[themeName] = theme;
-    this.globals[themeName] = this.validateDefinition(themeName, globalSheet, this.globals);
+    this.globals[themeName] = this.validateDefinition(themeName, globalSheet);
 
     return this;
   }
@@ -373,11 +373,9 @@ export default abstract class Aesthetic<
   /**
    * Validate a style sheet or theme definition.
    */
-  private validateDefinition<T>(key: string, value: T, cache: { [key: string]: T }): T {
+  private validateDefinition<T>(key: string, value: T): T {
     if (__DEV__) {
-      if (cache[key]) {
-        throw new Error(`Styles have already been defined for "${key}".`);
-      } else if (value !== null && typeof value !== 'function') {
+      if (value !== null && typeof value !== 'function') {
         throw new TypeError(`Definition for "${key}" must be null or a function.`);
       }
     }

--- a/packages/core/src/Aesthetic.tsx
+++ b/packages/core/src/Aesthetic.tsx
@@ -191,7 +191,7 @@ export default abstract class Aesthetic<
   /**
    * Return a theme object or throw an error.
    */
-  getTheme(name: ThemeName): Theme {
+  getTheme(name?: ThemeName): Theme {
     const themeName = name || this.options.theme;
     const theme = this.themes[themeName];
 

--- a/packages/core/src/Aesthetic.tsx
+++ b/packages/core/src/Aesthetic.tsx
@@ -43,7 +43,6 @@ export default abstract class Aesthetic<
       cxPropName: 'cx',
       extendable: false,
       passThemeProp: false,
-      pure: true,
       rtl: false,
       stylesPropName: 'styles',
       theme: 'default',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -119,7 +119,6 @@ export interface AestheticOptions {
   cxPropName: string;
   extendable: boolean;
   passThemeProp: boolean;
-  pure: boolean;
   rtl: boolean;
   stylesPropName: string;
   theme: ThemeName;

--- a/packages/core/tests/Aesthetic.test.tsx
+++ b/packages/core/tests/Aesthetic.test.tsx
@@ -463,14 +463,6 @@ describe('Aesthetic', () => {
   });
 
   describe('registerStyleSheet()', () => {
-    it('errors if styles have been set', () => {
-      instance.styles.foo = () => ({});
-
-      expect(() => {
-        instance.registerStyleSheet('foo', () => ({}));
-      }).toThrowErrorMatchingSnapshot();
-    });
-
     it('errors if styles try to extend from itself', () => {
       instance.styles.foo = () => ({});
 

--- a/packages/core/tests/Aesthetic.test.tsx
+++ b/packages/core/tests/Aesthetic.test.tsx
@@ -27,7 +27,6 @@ describe('Aesthetic', () => {
         cxPropName: 'cx',
         extendable: false,
         passThemeProp: false,
-        pure: true,
         rtl: false,
         stylesPropName: 'styleSheet',
         theme: 'default',

--- a/packages/core/tests/__snapshots__/Aesthetic.test.tsx.snap
+++ b/packages/core/tests/__snapshots__/Aesthetic.test.tsx.snap
@@ -20,8 +20,6 @@ exports[`Aesthetic registerStyleSheet() errors if styles are not a function 3`] 
 
 exports[`Aesthetic registerStyleSheet() errors if styles are not a function 4`] = `"Definition for \\"foo\\" must be null or a function."`;
 
-exports[`Aesthetic registerStyleSheet() errors if styles have been set 1`] = `"Styles have already been defined for \\"foo\\"."`;
-
 exports[`Aesthetic registerStyleSheet() errors if styles try to extend from itself 1`] = `"Cannot extend styles from itself."`;
 
 exports[`Aesthetic registerTheme() errors if a theme name has been used 1`] = `"Theme \\"default\\" already exists."`;

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Updated `react` requirement to v16.6.
 - Updated `withStyles` HOC to receive the CSS transformer function as a `cx` prop.
+- Updated `withStyles` and `withTheme` HOCs to internally use function components instead of class
+  components.
 - **[TS]** Renamed the `WithStylesProps` interface to `WithStylesWrappedProps`.
 - **[TS]** Renamed the `WithThemeProps` interface to `WithThemeWrappedProps`.
 

--- a/packages/react/src/ThemeContext.ts
+++ b/packages/react/src/ThemeContext.ts
@@ -4,5 +4,5 @@ import { ThemeContextShape } from './types';
 export default React.createContext<ThemeContextShape>({
   changeTheme() {},
   theme: {},
-  themeName: 'default',
+  themeName: '',
 });

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -51,8 +51,6 @@ export interface WithThemeWrappedProps<Theme> {
 }
 
 export interface WithThemeOptions {
-  /** Render a pure component instead of a regular component. Provided by `withTheme`. */
-  pure?: boolean;
   /** Name of the prop in which to pass the theme object to the wrapped component. Provided by `withTheme`. */
   themePropName?: string;
 }
@@ -86,8 +84,6 @@ export interface WithStylesOptions {
   extendFrom?: string;
   /** Pass the theme object prop to the wrapped component. Provided by `withStyles`. */
   passThemeProp?: boolean;
-  /** Render a pure component instead of a regular component. Provided by `withStyles`. */
-  pure?: boolean;
   /** Name of the prop in which to pass styles to the wrapped component. Provided by `withStyles`. */
   stylesPropName?: string;
   /** Name of the prop in which to pass the theme object to the wrapped component. Provided by `withStyles`. */

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -6,7 +6,6 @@ import Aesthetic, {
   StyleName,
   StyleSheetDefinition,
   ThemeName,
-  TransformOptions,
 } from 'aesthetic';
 import { Omit } from 'utility-types';
 
@@ -34,8 +33,9 @@ export interface ThemeProviderState {
   themeName: ThemeName;
 }
 
-export interface WithThemeContextProps {
-  themeName: ThemeName;
+export interface UseStylesOptions {
+  /** Custom name for the component being styled. */
+  styleName?: string;
 }
 
 export interface WithThemeWrapperProps {
@@ -55,11 +55,6 @@ export interface WithThemeOptions {
   pure?: boolean;
   /** Name of the prop in which to pass the theme object to the wrapped component. Provided by `withTheme`. */
   themePropName?: string;
-}
-
-export interface WithStylesContextProps {
-  dir: Direction;
-  themeName: ThemeName;
 }
 
 export interface WithStylesWrapperProps {
@@ -82,11 +77,6 @@ export interface WithStylesWrappedProps<
   theme?: Theme;
 }
 
-export interface WithStylesState<ParsedBlock> {
-  options: TransformOptions;
-  styles: SheetMap<ParsedBlock>;
-}
-
 export interface WithStylesOptions {
   /** Name of the prop in which to pass the CSS class name transformer function. Provided by `withStyles`. */
   cxPropName?: string;
@@ -104,7 +94,7 @@ export interface WithStylesOptions {
   themePropName?: string;
 }
 
-export interface StyledComponentClass<Theme, Props> extends React.ComponentClass<Props> {
+export interface StyledComponentClass<Theme, Props> extends React.FunctionComponent<Props> {
   displayName: string;
   styleName: StyleName;
   WrappedComponent: React.ComponentType<Props & WithStylesWrappedProps<Theme, any, any>>;

--- a/packages/react/src/useStylesFactory.ts
+++ b/packages/react/src/useStylesFactory.ts
@@ -3,6 +3,7 @@ import Aesthetic, { ClassNameTransformer, StyleSheetDefinition, SheetMap } from 
 import uuid from 'uuid/v4';
 import DirectionContext from './DirectionContext';
 import ThemeContext from './ThemeContext';
+import { UseStylesOptions } from './types';
 
 /**
  * Hook within a component to provide a style sheet.
@@ -16,12 +17,13 @@ export default function useStylesFactory<
 
   return function useStyles<T>(
     styleSheet: StyleSheetDefinition<Theme, T>,
-    customName: string = 'Component',
+    options: UseStylesOptions = {},
   ): [SheetMap<ParsedBlock>, CX, string] {
+    const { styleName: customName } = options;
     const dir = useContext(DirectionContext);
     const { themeName } = useContext(ThemeContext);
     const [styleName] = useState(() => {
-      const name = `${customName}-${uuid()}`;
+      const name = customName || `Component-${uuid()}`;
 
       aesthetic.registerStyleSheet(name, styleSheet);
 
@@ -29,8 +31,8 @@ export default function useStylesFactory<
     });
 
     // Create a unique style sheet for this component
-    const options = { dir, name: styleName, theme: themeName };
-    const sheet = aesthetic.createStyleSheet(styleName, options);
+    const params = { dir, name: styleName, theme: themeName };
+    const sheet = aesthetic.createStyleSheet(styleName, params);
 
     // Flush styles on mount
     useLayoutEffect(() => {
@@ -38,7 +40,7 @@ export default function useStylesFactory<
     }, [dir, styleName, themeName]);
 
     // Create a CSS transformer
-    const cx: CX = (...styles) => aesthetic.transformStyles(styles, options);
+    const cx: CX = (...styles) => aesthetic.transformStyles(styles, params);
 
     return [sheet, cx, styleName];
   };

--- a/packages/react/src/withStylesFactory.tsx
+++ b/packages/react/src/withStylesFactory.tsx
@@ -48,7 +48,7 @@ export default function withStylesFactory<
       aesthetic.registerStyleSheet(styleName, styleSheet, extendFrom);
 
       function WithStyles({ wrappedRef, ...props }: Props & WithStylesWrapperProps) {
-        const theme = useContext(ThemeContext);
+        const { themeName } = useContext(ThemeContext);
         const [styles, cx] = useStyles(styleSheet, { styleName });
         const extraProps: WithStylesWrappedProps<Theme, NativeBlock, ParsedBlock> = {
           [cxPropName as 'cx']: cx,
@@ -57,7 +57,7 @@ export default function withStylesFactory<
         };
 
         if (passThemeProp) {
-          extraProps[themePropName as 'theme'] = theme.theme as Theme;
+          extraProps[themePropName as 'theme'] = aesthetic.getTheme(themeName);
         }
 
         return <WrappedComponent {...props as any} {...extraProps} />;

--- a/packages/react/src/withStylesFactory.tsx
+++ b/packages/react/src/withStylesFactory.tsx
@@ -32,7 +32,6 @@ export default function withStylesFactory<
       extendable = aesthetic.options.extendable,
       extendFrom = '',
       passThemeProp = aesthetic.options.passThemeProp,
-      pure = aesthetic.options.pure,
       stylesPropName = aesthetic.options.stylesPropName,
       themePropName = aesthetic.options.themePropName,
     } = options;

--- a/packages/react/src/withThemeFactory.tsx
+++ b/packages/react/src/withThemeFactory.tsx
@@ -21,9 +21,9 @@ export default function withThemeFactory<
       const baseName = WrappedComponent.displayName || WrappedComponent.name;
 
       function WithTheme({ wrappedRef, ...props }: Props & WithThemeWrapperProps) {
-        const theme = useContext(ThemeContext);
+        const { themeName } = useContext(ThemeContext);
         const extraProps: WithThemeWrappedProps<Theme> = {
-          [themePropName as 'theme']: theme.theme as Theme,
+          [themePropName as 'theme']: aesthetic.getTheme(themeName),
           ref: wrappedRef,
         };
 

--- a/packages/react/src/withThemeFactory.tsx
+++ b/packages/react/src/withThemeFactory.tsx
@@ -13,10 +13,7 @@ export default function withThemeFactory<
   ParsedBlock extends object | string = NativeBlock
 >(aesthetic: Aesthetic<Theme, NativeBlock, ParsedBlock>) /* infer */ {
   return function withTheme(options: WithThemeOptions = {}) /* infer */ {
-    const {
-      pure = aesthetic.options.pure,
-      themePropName = aesthetic.options.themePropName,
-    } = options;
+    const { themePropName = aesthetic.options.themePropName } = options;
 
     return function withThemeComposer<Props extends object = {}>(
       WrappedComponent: React.ComponentType<Props & WithThemeWrappedProps<Theme>>,

--- a/packages/react/tests/useStylesFactory.test.tsx
+++ b/packages/react/tests/useStylesFactory.test.tsx
@@ -60,7 +60,7 @@ describe('useStylesFactory()', () => {
 
     shallow(<Component />);
 
-    expect(spy).toHaveBeenCalledWith(styleName, { dir: 'ltr', name: styleName, theme: 'default' });
+    expect(spy).toHaveBeenCalledWith(styleName, { dir: 'ltr', name: styleName, theme: '' });
   });
 
   it('flushes styles only once', () => {
@@ -154,7 +154,7 @@ describe('useStylesFactory()', () => {
     expect(createSpy).toHaveBeenCalledWith(styleName, {
       dir: 'rtl',
       name: styleName,
-      theme: 'default',
+      theme: '',
     });
 
     act(() => {
@@ -169,7 +169,7 @@ describe('useStylesFactory()', () => {
     expect(createSpy).toHaveBeenCalledWith(styleName, {
       dir: 'ltr',
       name: styleName,
-      theme: 'default',
+      theme: '',
     });
   });
 
@@ -228,12 +228,12 @@ describe('useStylesFactory()', () => {
       expect(createSpy).toHaveBeenCalledWith(styleName, {
         dir: 'rtl',
         name: styleName,
-        theme: 'default',
+        theme: '',
       });
       expect(transformSpy).toHaveBeenCalledWith([{}, {}], {
         dir: 'rtl',
         name: styleName,
-        theme: 'default',
+        theme: '',
       });
     });
 
@@ -253,12 +253,12 @@ describe('useStylesFactory()', () => {
       expect(createSpy).toHaveBeenCalledWith(styleName, {
         dir: 'rtl',
         name: styleName,
-        theme: 'default',
+        theme: '',
       });
       expect(transformSpy).toHaveBeenCalledWith([{}, {}], {
         dir: 'rtl',
         name: styleName,
-        theme: 'default',
+        theme: '',
       });
     });
   });

--- a/packages/react/tests/withStylesFactory.test.tsx
+++ b/packages/react/tests/withStylesFactory.test.tsx
@@ -175,7 +175,7 @@ describe('withStylesFactory()', () => {
     expect(spy).toHaveBeenCalledWith(Wrapped.styleName, {
       dir: 'ltr',
       name: Wrapped.styleName,
-      theme: 'default',
+      theme: '',
     });
   });
 
@@ -302,7 +302,7 @@ describe('withStylesFactory()', () => {
     expect(createSpy).toHaveBeenCalledWith(Wrapped.styleName, {
       dir: 'rtl',
       name: Wrapped.styleName,
-      theme: 'default',
+      theme: '',
     });
 
     act(() => {
@@ -317,7 +317,7 @@ describe('withStylesFactory()', () => {
     expect(createSpy).toHaveBeenCalledWith(Wrapped.styleName, {
       dir: 'ltr',
       name: Wrapped.styleName,
-      theme: 'default',
+      theme: '',
     });
   });
 
@@ -380,12 +380,12 @@ describe('withStylesFactory()', () => {
       expect(createSpy).toHaveBeenCalledWith(Wrapped.styleName, {
         dir: 'rtl',
         name: Wrapped.styleName,
-        theme: 'default',
+        theme: '',
       });
       expect(transformSpy).toHaveBeenCalledWith([{}, {}], {
         dir: 'rtl',
         name: Wrapped.styleName,
-        theme: 'default',
+        theme: '',
       });
     });
 
@@ -407,12 +407,12 @@ describe('withStylesFactory()', () => {
       expect(createSpy).toHaveBeenCalledWith(Wrapped.styleName, {
         dir: 'rtl',
         name: Wrapped.styleName,
-        theme: 'default',
+        theme: '',
       });
       expect(transformSpy).toHaveBeenCalledWith([{}, {}], {
         dir: 'rtl',
         name: Wrapped.styleName,
-        theme: 'default',
+        theme: '',
       });
     });
   });

--- a/packages/react/tests/withStylesFactory.test.tsx
+++ b/packages/react/tests/withStylesFactory.test.tsx
@@ -13,9 +13,9 @@ describe('withStylesFactory()', () => {
 
   beforeEach(() => {
     aesthetic = new TestAesthetic();
-    withStyles = withStylesFactory(aesthetic);
-
     registerTestTheme(aesthetic);
+
+    withStyles = withStylesFactory(aesthetic);
   });
 
   function BaseComponent() {
@@ -40,10 +40,7 @@ describe('withStylesFactory()', () => {
     return shallow(element, {
       // @ts-ignore Not yet typed
       wrappingComponent: WrappingComponent,
-    })
-      .dive()
-      .dive()
-      .dive();
+    });
   }
 
   it('returns an HOC component', () => {
@@ -94,6 +91,8 @@ describe('withStylesFactory()', () => {
       },
     });
     const Wrapped = withStyles(styles)(BaseComponent);
+
+    shallowDeep(<Wrapped />);
 
     expect(aesthetic.styles[Wrapped.styleName]).toBe(styles);
   });
@@ -164,22 +163,19 @@ describe('withStylesFactory()', () => {
     const Wrapped = withStyles(() => ({}), { passThemeProp: true })(ThemeComponent);
     const wrapper = shallowDeep(<Wrapped />);
 
-    expect(wrapper.prop('theme')).toEqual({ color: 'black', unit: 8 });
+    expect(wrapper.prop('theme')).toBeDefined();
   });
 
   it('creates a style sheet', () => {
     const spy = jest.spyOn(aesthetic, 'createStyleSheet');
     const Wrapped = withStyles(() => TEST_STATEMENT)(StyledComponent);
-    const wrapper = shallowDeep(<Wrapped foo="abc" />);
+
+    shallowDeep(<Wrapped foo="abc" />);
 
     expect(spy).toHaveBeenCalledWith(Wrapped.styleName, {
       dir: 'ltr',
       name: Wrapped.styleName,
-      theme: 'light',
-    });
-    expect(wrapper.state('styles')).toEqual({
-      header: {},
-      footer: {},
+      theme: 'default',
     });
   });
 

--- a/packages/react/tests/withStylesFactory.test.tsx
+++ b/packages/react/tests/withStylesFactory.test.tsx
@@ -163,7 +163,7 @@ describe('withStylesFactory()', () => {
     const Wrapped = withStyles(() => ({}), { passThemeProp: true })(ThemeComponent);
     const wrapper = shallowDeep(<Wrapped />);
 
-    expect(wrapper.prop('theme')).toBeDefined();
+    expect(wrapper.prop('theme')).toEqual({ color: 'black', unit: 8 });
   });
 
   it('creates a style sheet', () => {

--- a/packages/react/tests/withThemeFactory.test.tsx
+++ b/packages/react/tests/withThemeFactory.test.tsx
@@ -12,9 +12,9 @@ describe('withThemeFactory()', () => {
 
   beforeEach(() => {
     aesthetic = new TestAesthetic();
-    withTheme = withThemeFactory(aesthetic);
-
     registerTestTheme(aesthetic);
+
+    withTheme = withThemeFactory(aesthetic);
   });
 
   function BaseComponent() {
@@ -33,9 +33,7 @@ describe('withThemeFactory()', () => {
     return shallow(element, {
       // @ts-ignore Not yet typed
       wrappingComponent: WrappingComponent,
-    })
-      .dive()
-      .dive();
+    });
   }
 
   it('returns an HOC component', () => {
@@ -79,7 +77,7 @@ describe('withThemeFactory()', () => {
     const Wrapped = withTheme()(ThemeComponent);
     const wrapper = shallowDeep(<Wrapped />);
 
-    expect(wrapper.prop('theme')).toEqual({ color: 'black', unit: 8 });
+    expect(wrapper.prop('theme')).toBeDefined();
   });
 
   it('can bubble up the ref with `wrappedRef`', () => {

--- a/packages/react/tests/withThemeFactory.test.tsx
+++ b/packages/react/tests/withThemeFactory.test.tsx
@@ -77,7 +77,7 @@ describe('withThemeFactory()', () => {
     const Wrapped = withTheme()(ThemeComponent);
     const wrapper = shallowDeep(<Wrapped />);
 
-    expect(wrapper.prop('theme')).toBeDefined();
+    expect(wrapper.prop('theme')).toEqual({ color: 'black', unit: 8 });
   });
 
   it('can bubble up the ref with `wrappedRef`', () => {

--- a/tests/bundle.tsx
+++ b/tests/bundle.tsx
@@ -42,7 +42,7 @@ function registerThemes(aesthetic: Aesthetic<Theme, any, any>) {
   }
 
   aesthetic.registerTheme(
-    'light',
+    'default',
     {
       unit: 8,
       fg: '#fff',
@@ -64,7 +64,8 @@ function registerThemes(aesthetic: Aesthetic<Theme, any, any>) {
     }),
   );
 
-  aesthetic.extendTheme('dark', 'light', {
+  aesthetic.extendTheme('light', 'default', {});
+  aesthetic.extendTheme('dark', 'default', {
     fg: '#eee',
     bg: '#212121',
     bgHover: '#424242',
@@ -172,7 +173,7 @@ function createHookComponent(aesthetic: Aesthetic<Theme, any, any>) {
   const useStyles = useStylesFactory(aesthetic);
   const useTheme = useThemeFactory(aesthetic);
 
-  return function Button({ children, primary = false }: HocProps) {
+  return function Button({ children, primary = false }: HookProps) {
     const [styles, cx] = useStyles(styleSheet);
     const theme = useTheme();
     const className = cx(styles.button, primary && styles.button__primary);


### PR DESCRIPTION
HOCs suck, especially because of the many layers of context nesting. This PR is a proof of concept on replacing the internal HOC classes with functions + hooks to achieve the same effect.

And since we're not using classes anymore, we can remove the `pure` option.

The added bonus to this is that we no longer need to dive within Enzyme.