### PR TITLE
Switch to useRef over useState.

### DIFF
--- a/packages/react/src/useStylesFactory.ts
+++ b/packages/react/src/useStylesFactory.ts
@@ -34,15 +34,12 @@ export default function useStylesFactory<
       aesthetic.registerStyleSheet(styleName, styleSheet);
     }
 
-    console.log({ ref, dir, themeName, styleName });
-
     // Create a unique style sheet for this component
     const params = { dir, name: styleName, theme: themeName };
     const sheet = aesthetic.createStyleSheet(styleName, params);
 
     // Flush styles on mount
     useLayoutEffect(() => {
-      console.log('FLUSH');
       aesthetic.flushStyles(styleName);
     }, [dir, styleName, themeName]);
 

--- a/packages/react/src/useStylesFactory.ts
+++ b/packages/react/src/useStylesFactory.ts
@@ -1,4 +1,4 @@
-import { useContext, useState, useLayoutEffect } from 'react';
+import { useContext, useRef, useLayoutEffect } from 'react';
 import Aesthetic, { ClassNameTransformer, StyleSheetDefinition, SheetMap } from 'aesthetic';
 import uuid from 'uuid/v4';
 import DirectionContext from './DirectionContext';
@@ -20,15 +20,21 @@ export default function useStylesFactory<
     options: UseStylesOptions = {},
   ): [SheetMap<ParsedBlock>, CX, string] {
     const { styleName: customName } = options;
+    const ref = useRef<string>();
     const dir = useContext(DirectionContext);
     const themeName = useContext(ThemeContext);
-    const [styleName] = useState(() => {
-      const name = customName || `Component-${uuid()}`;
+    let styleName = '';
 
-      aesthetic.registerStyleSheet(name, styleSheet);
+    // Only register the style sheet once
+    if (ref.current) {
+      styleName = ref.current;
+    } else {
+      styleName = customName || uuid();
+      ref.current = styleName;
+      aesthetic.registerStyleSheet(styleName, styleSheet);
+    }
 
-      return name;
-    });
+    console.log({ ref, dir, themeName, styleName });
 
     // Create a unique style sheet for this component
     const params = { dir, name: styleName, theme: themeName };
@@ -36,6 +42,7 @@ export default function useStylesFactory<
 
     // Flush styles on mount
     useLayoutEffect(() => {
+      console.log('FLUSH');
       aesthetic.flushStyles(styleName);
     }, [dir, styleName, themeName]);
 

--- a/packages/react/tests/useStylesFactory.test.tsx
+++ b/packages/react/tests/useStylesFactory.test.tsx
@@ -63,7 +63,7 @@ describe('useStylesFactory()', () => {
     expect(spy).toHaveBeenCalledWith(styleName, { dir: 'ltr', name: styleName, theme: '' });
   });
 
-  it.only('flushes styles only once', () => {
+  it('flushes styles only once', () => {
     const spy = jest.spyOn(aesthetic, 'flushStyles');
 
     act(() => {
@@ -79,8 +79,6 @@ describe('useStylesFactory()', () => {
       // Check that its called once
       ReactDOM.render(<Component />, container);
     });
-
-    console.log(spy.mock);
 
     expect(spy).toHaveBeenCalledWith(styleName);
     expect(spy).toHaveBeenCalledTimes(2); // Once for :root

--- a/packages/react/tests/useStylesFactory.test.tsx
+++ b/packages/react/tests/useStylesFactory.test.tsx
@@ -63,7 +63,7 @@ describe('useStylesFactory()', () => {
     expect(spy).toHaveBeenCalledWith(styleName, { dir: 'ltr', name: styleName, theme: '' });
   });
 
-  it('flushes styles only once', () => {
+  it.only('flushes styles only once', () => {
     const spy = jest.spyOn(aesthetic, 'flushStyles');
 
     act(() => {
@@ -79,6 +79,8 @@ describe('useStylesFactory()', () => {
       // Check that its called once
       ReactDOM.render(<Component />, container);
     });
+
+    console.log(spy.mock);
 
     expect(spy).toHaveBeenCalledWith(styleName);
     expect(spy).toHaveBeenCalledTimes(2); // Once for :root

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,7 +2382,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/uuid@3.4.5":
+"@types/uuid@*":
   version "3.4.5"
   resolved "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz#d4dc10785b497a1474eae0ba7f0cb09c0ddfd6eb"
   integrity sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==


### PR DESCRIPTION
`useState` hook is async and causes re-renders. We don't really need that, we need sync with a single render.