### PR TITLE
Add `TestAesthetic` for easily testing class name changes

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
   - [Global At-rules](./unified/global-at.md)
   - [Local At-rules](./unified/local-at.md)
 - [Right-to-Left](./rtl.md)
+- [Testing](./testing.md)
 - [Competitors Comparison](./comparison.md)
 - Migration Guides
   - [2.0](./migrate/2.0.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,59 @@
+# Testing
+
+Testing Aesthetic styled components can be tricky, as adapter generated class names may change, or
+be hashed, and basically be non-deterministic. To mitigate this issue, we provide a `TestAesthetic`
+adapter, which uses the style sheet keys as the class names, which allows for deterministic
+assertions.
+
+```ts
+import { TestAesthetic } from 'aesthetic/lib/testUtils';
+import { Theme } from './types';
+
+const aesthetic = new TestAesthetic<Theme>();
+```
+
+Besides `TestAesthetic`, there are a handful of constants and functions that can be found in the
+[testing utilities](https://github.com/milesj/aesthetic/blob/master/packages/core/src/testUtils.ts).
+
+## Enzyme
+
+### `withStyles` Components
+
+When shallow testing components wrapped with `withStyles`, you'll need to `dive()` after the
+shallow. This will return the underlying component with the styles and props applied.
+
+```ts
+const wrapper = shallow(<StyledComponent />).dive();
+```
+
+### `className` Changes
+
+To test class name changes, like an active state being applied, simply match against the `className`
+prop. This requires the `TestAesthetic` adapter mentioned above.
+
+```tsx
+function Component({ active, children }: Props) {
+  const [styles, cx] = useStyles(() => ({
+    button: {},
+    button__active: {},
+  }));
+
+  return (
+    <button type="button" className={cx(styles.button, active && styles.button__active)}>
+      {children}
+    </button>
+  );
+}
+```
+
+```tsx
+it('sets active class name', () => {
+  const wrapper = shallow(<Component />);
+
+  expect(wrapper.prop('className')).toBe('button');
+
+  wrapper.setProps({ active: true });
+
+  expect(wrapper.prop('className')).toBe('button button__active');
+});
+```

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.1.0 - 2019-07-10
+
+#### 🚀 Updates
+
+- Added a `TestAesthetic` adapter to make testing class names much easier.
+
 # 4.0.0 - 2019-07-07
 
 To support right-to-left, dynamic themes, and other frameworks besides React, the core APIs had to

--- a/packages/core/src/TestAesthetic.ts
+++ b/packages/core/src/TestAesthetic.ts
@@ -1,0 +1,26 @@
+import Aesthetic from './Aesthetic';
+import { ClassName, SheetMap } from './types';
+
+export default class TestAesthetic<Theme extends object = any> extends Aesthetic<
+  Theme,
+  any,
+  string
+> {
+  isParsedBlock(block: unknown): block is string {
+    return typeof block === 'string';
+  }
+
+  parseStyleSheet(styleSheet: SheetMap<any>): SheetMap<string> {
+    return Object.keys(styleSheet).reduce(
+      (obj, key) => ({
+        ...obj,
+        [key]: key,
+      }),
+      {},
+    );
+  }
+
+  transformToClassName(styles: string[]): ClassName {
+    return styles.filter(style => style && typeof style === 'string').join(' ');
+  }
+}

--- a/packages/core/src/testUtils.ts
+++ b/packages/core/src/testUtils.ts
@@ -8,20 +8,15 @@ import {
   isObject,
 } from 'aesthetic-utils';
 import Aesthetic from './Aesthetic';
+import TestAesthetic from './TestAesthetic';
 import { FontFace, Direction } from './types';
 import { GLOBAL_STYLE_NAME } from './constants';
 
-export { getStyleElements };
+export { TestAesthetic };
 
 export interface TestTheme {
   color: string;
   unit: number;
-}
-
-export class TestAesthetic extends Aesthetic<TestTheme, any, any> {
-  transformToClassName(styles: any[]): string {
-    return styles.map((style, i) => `class-${i}`).join(' ');
-  }
 }
 
 export function registerTestTheme(aesthetic: Aesthetic<TestTheme, any, any>) {

--- a/packages/core/tests/Aesthetic.test.tsx
+++ b/packages/core/tests/Aesthetic.test.tsx
@@ -1,16 +1,11 @@
 import Aesthetic from '../src/Aesthetic';
+import TestAesthetic from '../src/TestAesthetic';
 import StyleSheetManager from '../src/StyleSheetManager';
 import { GLOBAL_STYLE_NAME } from '../src/constants';
 import { TestTheme, registerTestTheme, SYNTAX_GLOBAL } from '../src/testUtils';
 
 describe('Aesthetic', () => {
   let instance: Aesthetic<TestTheme, any, any>;
-
-  class TestAesthetic extends Aesthetic<TestTheme, any, any> {
-    transformToClassName(styles: any[]): string {
-      return styles.map((style, i) => `class-${i}`).join(' ');
-    }
-  }
 
   beforeEach(() => {
     instance = new TestAesthetic();

--- a/packages/core/tests/Aesthetic.test.tsx
+++ b/packages/core/tests/Aesthetic.test.tsx
@@ -164,7 +164,7 @@ describe('Aesthetic', () => {
 
     it('returns the style sheet', () => {
       expect(instance.createStyleSheet('foo', {})).toEqual({
-        el: {},
+        el: 'el',
       });
     });
 
@@ -437,10 +437,9 @@ describe('Aesthetic', () => {
 
   describe('parseStyleSheet()', () => {
     it('returns the style sheet as an object', () => {
-      const sheet = { el: {} };
-      const styleSheet = instance.parseStyleSheet(sheet, 'styleName');
+      const styleSheet = instance.parseStyleSheet({ el: {} }, 'styleName');
 
-      expect(sheet).toEqual(styleSheet);
+      expect(styleSheet).toEqual({ el: 'el' });
     });
   });
 
@@ -589,7 +588,7 @@ describe('Aesthetic', () => {
 
       instance.transformStyles([{ color: 'red' }, { display: 'block' }], {});
 
-      expect(spy).toHaveBeenCalledWith([{ color: 'red' }, { display: 'block' }]);
+      expect(spy).toHaveBeenCalledWith(['inline-0', 'inline-1']);
     });
 
     it('ignores falsey values', () => {

--- a/packages/react/tests/useStylesFactory.test.tsx
+++ b/packages/react/tests/useStylesFactory.test.tsx
@@ -15,7 +15,7 @@ describe('useStylesFactory()', () => {
 
   beforeEach(() => {
     aesthetic = new TestAesthetic();
-    useStyles = useStylesFactory(aesthetic);
+    useStyles = useStylesFactory(aesthetic) as any;
     styleName = '';
     container = document.createElement('div');
 
@@ -102,7 +102,7 @@ describe('useStylesFactory()', () => {
   it('can transform class names', () => {
     const wrapper = shallow(<StyledComponent />);
 
-    expect(wrapper.prop('className')).toBe('class-0 class-1');
+    expect(wrapper.prop('className')).toBe('header footer');
   });
 
   it('re-creates style sheet if theme context changes', () => {
@@ -230,7 +230,7 @@ describe('useStylesFactory()', () => {
         name: styleName,
         theme: '',
       });
-      expect(transformSpy).toHaveBeenCalledWith([{}, {}], {
+      expect(transformSpy).toHaveBeenCalledWith(['header', 'footer'], {
         dir: 'rtl',
         name: styleName,
         theme: '',
@@ -255,7 +255,7 @@ describe('useStylesFactory()', () => {
         name: styleName,
         theme: '',
       });
-      expect(transformSpy).toHaveBeenCalledWith([{}, {}], {
+      expect(transformSpy).toHaveBeenCalledWith(['header', 'footer'], {
         dir: 'rtl',
         name: styleName,
         theme: '',

--- a/packages/react/tests/withStylesFactory.test.tsx
+++ b/packages/react/tests/withStylesFactory.test.tsx
@@ -246,7 +246,7 @@ describe('withStylesFactory()', () => {
     const Wrapped = withStyles(() => TEST_STATEMENT)(Component);
     const wrapper = shallowDeep(<Wrapped />).dive();
 
-    expect(wrapper.prop('className')).toBe('class-0 class-1');
+    expect(wrapper.prop('className')).toBe('header footer');
   });
 
   it('re-creates style sheet if theme context changes', () => {
@@ -382,7 +382,7 @@ describe('withStylesFactory()', () => {
         name: Wrapped.styleName,
         theme: '',
       });
-      expect(transformSpy).toHaveBeenCalledWith([{}, {}], {
+      expect(transformSpy).toHaveBeenCalledWith(['header', 'footer'], {
         dir: 'rtl',
         name: Wrapped.styleName,
         theme: '',
@@ -409,7 +409,7 @@ describe('withStylesFactory()', () => {
         name: Wrapped.styleName,
         theme: '',
       });
-      expect(transformSpy).toHaveBeenCalledWith([{}, {}], {
+      expect(transformSpy).toHaveBeenCalledWith(['header', 'footer'], {
         dir: 'rtl',
         name: Wrapped.styleName,
         theme: '',


### PR DESCRIPTION
As the title states. At the moment, this is currently very difficult with each adapter's class name generation and hashing.